### PR TITLE
chore: enable update checker for proton repos

### DIFF
--- a/com.protonvpn.www.yml
+++ b/com.protonvpn.www.yml
@@ -539,7 +539,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/ProtonVPN/python-proton-keyring-linux
-        branch: master
+        branch: unstable
         commit: 5ff3c7f9a1a162836649502dd23c2fbe1f487d73
 
   - name: python-proton-keyring-linux-secretservice


### PR DESCRIPTION
Track the master branches since the upstream repos are not tagged