### PR TITLE
fix: Ref not found on build

### DIFF
--- a/com.protonvpn.www.yml
+++ b/com.protonvpn.www.yml
@@ -715,11 +715,12 @@ modules:
     sources:
       - type: git
         url: https://github.com/ProtonVPN/python-proton-vpn-api-core
+        # tag: 0.20.1
         commit: 9c03fc30d3ff08559cab3644eadde027b029375d
-        x-checker-data:
-          type: anitya
-          project-id: 369944
-          tag-template: $version
+        # x-checker-data:
+        #   type: anitya
+        #   project-id: 369944
+        #   tag-template: $version
 
   - name: proton-vpn-gtk-app
     buildsystem: simple


### PR DESCRIPTION
```
ERROR   src.manifest: Failed to check git python-proton-vpn-api-core/python-proton-vpn-api-core with AnityaChecker: Ref not found in https://github.com/ProtonVPN/python-proton-vpn-api-core: 'refs/tags/0.20.1'
```

https://github.com/ProtonVPN/python-proton-vpn-api-core/issues/1