### PR TITLE
fix: workaround for update check if no tags provided by upstream

### DIFF
--- a/com.protonvpn.www.yml
+++ b/com.protonvpn.www.yml
@@ -538,12 +538,13 @@ modules:
     sources:
       - type: git
         url: https://github.com/ProtonVPN/python-proton-core
-        tag: 0.1.15
+        # tag: 0.1.15
+        branch: master
         commit: 5e795e04094dff67c03c56f2f3de03ff43514cc4
-        x-checker-data:
-          type: anitya
-          project-id: 369954
-          tag-template: $version
+        # x-checker-data:
+        #   type: anitya
+        #   project-id: 369954
+        #   tag-template: $version
 
   - name: python-proton-keyring-linux
     buildsystem: simple
@@ -558,12 +559,13 @@ modules:
     sources:
       - type: git
         url: https://github.com/ProtonVPN/python-proton-keyring-linux
-        tag: 0.0.1
+        # tag: 0.0.1
+        branch: unstable
         commit: 5ff3c7f9a1a162836649502dd23c2fbe1f487d73
-        x-checker-data:
-          type: anitya
-          project-id: 369953
-          tag-template: $version
+        # x-checker-data:
+        #   type: anitya
+        #   project-id: 369953
+        #   tag-template: $version
 
   - name: python-proton-keyring-linux-secretservice
     buildsystem: simple
@@ -573,12 +575,13 @@ modules:
     sources:
       - type: git
         url: https://github.com/ProtonVPN/python-proton-keyring-linux-secretservice
-        tag: 0.0.1
+        # tag: 0.0.1
+        branch: master
         commit: 973d2646ec4d04bc270df53058df892950244e70
-        x-checker-data:
-          type: anitya
-          project-id: 369952
-          tag-template: $version
+        # x-checker-data:
+        #   type: anitya
+        #   project-id: 369952
+        #   tag-template: $version
 
   - name: python-proton-vpn-logger
     buildsystem: simple
@@ -588,12 +591,13 @@ modules:
     sources:
       - type: git
         url: https://github.com/ProtonVPN/python-proton-vpn-logger
-        tag: 0.2.1
+        # tag: 0.2.1
+        branch: master
         commit: 0acbc1ab41a65cbc9ceb340e3db011e6f89eb65a
-        x-checker-data:
-          type: anitya
-          project-id: 369951
-          tag-template: $version
+        # x-checker-data:
+        #   type: anitya
+        #   project-id: 369951
+        #   tag-template: $version
 
   - name: python-proton-vpn-killswitch
     buildsystem: simple
@@ -603,12 +607,13 @@ modules:
     sources:
       - type: git
         url: https://github.com/ProtonVPN/python-proton-vpn-killswitch
-        tag: 0.2.0
+        # tag: 0.2.0
+        branch: master
         commit: 6e84588ea6ae0946141d4b44b2cf5df8465d5eba
-        x-checker-data:
-          type: anitya
-          project-id: 369950
-          tag-template: $version
+        # x-checker-data:
+        #   type: anitya
+        #   project-id: 369950
+        #   tag-template: $version
 
   - name: python-proton-vpn-killswitch-network-manager
     buildsystem: simple
@@ -622,12 +627,13 @@ modules:
     sources:
       - type: git
         url: https://github.com/ProtonVPN/python-proton-vpn-killswitch-network-manager
-        tag: 0.2.0
+        # tag: 0.2.0
+        branch: master
         commit: 39d4398f169539e335c1f661e0dfc5551df0e6af
-        x-checker-data:
-          type: anitya
-          project-id: 369949
-          tag-template: $version
+        # x-checker-data:
+        #   type: anitya
+        #   project-id: 369949
+        #   tag-template: $version
 
   - name: python-proton-vpn-connection
     buildsystem: simple
@@ -641,12 +647,13 @@ modules:
     sources:
       - type: git
         url: https://github.com/ProtonVPN/python-proton-vpn-connection
-        tag: 0.11.0
+        # tag: 0.11.0
+        branch: master
         commit: 747ccacb5350ad59f2a09953b8d20c5c161aab54
-        x-checker-data:
-          type: anitya
-          project-id: 369948
-          tag-template: $version
+        # x-checker-data:
+        #   type: anitya
+        #   project-id: 369948
+        #   tag-template: $version
 
   - name: python-proton-vpn-network-manager
     buildsystem: simple
@@ -660,12 +667,13 @@ modules:
     sources:
       - type: git
         url: https://github.com/ProtonVPN/python-proton-vpn-network-manager
-        tag: 0.3.0
+        # tag: 0.3.0
+        branch: master
         commit: 6ffd04fa0ae88a89d2b733443317066ef23b3ccd
-        x-checker-data:
-          type: anitya
-          project-id: 369947
-          tag-template: $version
+        # x-checker-data:
+        #   type: anitya
+        #   project-id: 369947
+        #   tag-template: $version
 
   - name: python-proton-vpn-network-manager-openvpn
     buildsystem: simple
@@ -675,12 +683,13 @@ modules:
     sources:
       - type: git
         url: https://github.com/ProtonVPN/python-proton-vpn-network-manager-openvpn
-        tag: 0.0.4
+        # tag: 0.0.4
+        branch: master
         commit: b79f6732646378ef1b92696de3665ff9560286d3
-        x-checker-data:
-          type: anitya
-          project-id: 369946
-          tag-template: $version
+        # x-checker-data:
+        #   type: anitya
+        #   project-id: 369946
+        #   tag-template: $version
 
   - name: python-proton-vpn-session
     buildsystem: simple
@@ -695,7 +704,8 @@ modules:
       - type: git
         url: https://github.com/ProtonVPN/python-proton-vpn-session
         # tag: 0.6.2
-        commit: 419b25bd1823f78d1219dc4cc441eeaf37646068
+        branch: master
+        commit: 91b50eabc5e9a8aaf1f2784b849bac875c6c0415
         # x-checker-data:
         #   type: anitya
         #   project-id: 369945
@@ -714,7 +724,8 @@ modules:
       - type: git
         url: https://github.com/ProtonVPN/python-proton-vpn-api-core
         # tag: 0.20.1
-        commit: 9c03fc30d3ff08559cab3644eadde027b029375d
+        branch: master
+        commit: 59a1cf008333ae357ada2fc7128694c2288b88da
         # x-checker-data:
         #   type: anitya
         #   project-id: 369944
@@ -752,6 +763,7 @@ modules:
         url: https://github.com/ProtonVPN/proton-vpn-gtk-app
         # tag: 4.1.0
         commit: 713324e9e4ee9f030c8115072cae379eb3340c42
+        branch: master
         # x-checker-data:
         #   type: anitya
         #   project-id: 369943


### PR DESCRIPTION
Since the upstream [no longer tags versions](https://github.com/ProtonVPN/python-proton-vpn-api-core/issues/1#issuecomment-1801837525), we need to track the main branches directly.