### PR TITLE
fix: `No module named 'proton.vpn.core.reports'`

### DIFF
--- a/com.protonvpn.www.yml
+++ b/com.protonvpn.www.yml
@@ -714,7 +714,7 @@ modules:
       - type: git
         url: https://github.com/ProtonVPN/python-proton-vpn-api-core
         # tag: 0.20.1
-        commit: bdd8de48600b52acc17973af33b2e4f846f4aec2
+        commit: 9c03fc30d3ff08559cab3644eadde027b029375d
         # x-checker-data:
         #   type: anitya
         #   project-id: 369944


### PR DESCRIPTION
Fixes #131