### PR TITLE
metainfo: Add developer

### DIFF
--- a/com.protonvpn.www.metainfo.xml
+++ b/com.protonvpn.www.metainfo.xml
@@ -5,6 +5,9 @@
     <project_license>GPL-3.0</project_license>
     <name>Proton VPN</name>
     <developer_name>Proton AG</developer_name>
+    <developer id="ch.protonmail">
+        <name>Proton AG</name>
+    </developer>
     <summary>Trusted and easy-to-use VPN app for Linux</summary>
     <launchable type="desktop-id">com.protonvpn.www.desktop</launchable>
     <description>


### PR DESCRIPTION
We sync this with other Proton apps at Flathub.

Fixes the second lint at:
```
flatpak run --command=flatpak-builder-lint org.flatpak.Builder appstream *metainfo* I: com.protonvpn.www:7: developer-name-tag-deprecated
   The toplevel `developer_name` element is deprecated. Please use the `name` element in a
   `developer` block instead.

I: com.protonvpn.www:~: developer-info-missing
   This component contains no `developer` element with information about its author.
```
Do note that most frontends have not implemented `developer` so we cannot just remove `developer_name`.