### PR TITLE
refactor: enable update checker for most proton modules

### DIFF
--- a/com.protonvpn.www.metainfo.xml
+++ b/com.protonvpn.www.metainfo.xml
@@ -140,9 +140,10 @@
     <url type="vcs-browser">https://github.com/ProtonVPN/proton-vpn-gtk-app</url>
 
     <releases>
-        <release version="4.1.10" date="2024-01-26" />
-        <release version="4.1.0" date="2023-11-02" />
-        <release version="4.0.0" date="2023-10-10" />
+        <release version="4.2.0" date="2024-03-06"/>
+        <release version="4.1.10" date="2024-01-26"/>
+        <release version="4.1.0" date="2023-11-02"/>
+        <release version="4.0.0" date="2023-10-10"/>
     </releases>
 
     <content_rating type="oars-1.1">

--- a/com.protonvpn.www.yml
+++ b/com.protonvpn.www.yml
@@ -769,8 +769,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/ProtonVPN/proton-vpn-gtk-app
-        tag: v4.1.10
-        commit: b2a9d4c3bba513078a0ddc9223e32fd3d44c2da4
+        tag: v4.2.0
+        commit: 2323032283015494dddf8b8dd6d0372ee1f05698
         x-checker-data:
           type: anitya
           project-id: 369943


### PR DESCRIPTION
Given that https://github.com/ProtonVPN/python-proton-vpn-api-core/issues/1#issuecomment-1976252786 is resolved.

~~A gotcha is that `python-proton-vpn-logger`'s tags seems not to be updated.~~