### PR TITLE
fix: tray icon image doesn't show in KDE

### DIFF
--- a/patches/proton-vpn-gtk-app/fix-tray-icons.patch
+++ b/patches/proton-vpn-gtk-app/fix-tray-icons.patch
@@ -1,49 +1,13 @@
-diff --git a/proton/vpn/app/gtk/widgets/main/tray_icon.py b/proton/vpn/app/gtk/widgets/main/tray_icon.py
-index db905e2..3f28410 100644
---- a/proton/vpn/app/gtk/widgets/main/tray_icon.py
-+++ b/proton/vpn/app/gtk/widgets/main/tray_icon.py
-@@ -57,7 +57,7 @@ logger = logging.getLogger(__name__)
+diff --git a/proton/vpn/app/gtk/util.py b/proton/vpn/app/gtk/util.py
+index 33c00ed..aba203e 100644
+--- a/proton/vpn/app/gtk/util.py
++++ b/proton/vpn/app/gtk/util.py
+@@ -22,7 +22,7 @@ from typing import Callable
+ from gi.repository import Gtk
  
- # Tray icon configuration
- TRAY_TITLE = "Proton VPN"
--TRAY_ICON_NAME = "proton-vpn-sign"
-+TRAY_ICON_NAME = "com.protonvpn.www.proton-vpn-sign"
- TRAY_ICON_DESCRIPTION = ""
+ # See: https://docs.gtk.org/gtk4/migrating-3to4.html#set-a-proper-application-id  # pylint: disable=line-too-long # noqa: E501
+-APPLICATION_ID = "proton.vpn.app.gtk"
++APPLICATION_ID = "com.protonvpn.www"
  
- # StatusNotifierItem specification
-@@ -239,7 +239,7 @@ class _StatusNotifierItem(dbus.service.Object):
-         self.bus = bus
  
-         # Generate unique bus name
--        self.bus_name_str = f"org.kde.StatusNotifierItem-{tray_icon.app_id}-{id(self)}"
-+        self.bus_name_str = f"com.protonvpn.www.StatusNotifierItem-{id(self)}"
-         self.bus_name = dbus.service.BusName(self.bus_name_str, bus)
- 
-         super().__init__(self.bus_name, object_path)
-diff --git a/proton/vpn/app/gtk/widgets/main/tray_indicator.py b/proton/vpn/app/gtk/widgets/main/tray_indicator.py
-index aef7227..a82793c 100644
---- a/proton/vpn/app/gtk/widgets/main/tray_indicator.py
-+++ b/proton/vpn/app/gtk/widgets/main/tray_indicator.py
-@@ -64,19 +64,19 @@ class TrayIndicator:
-         see `_on_connection_disconnected` for implementation details.
-     """
-     DISCONNECTED_ICON = str(
--        ICONS_PATH / f"state-{states.Disconnected.__name__.lower()}.svg"
-+        f"com.protonvpn.www.state-{states.Disconnected.__name__.lower()}"
-     )
-     DISCONNECTED_ICON_DESCRIPTION = str(
-         f"VPN {states.Disconnected.__name__.lower()}"
-     )
-     CONNECTED_ICON = str(
--        ICONS_PATH / f"state-{states.Connected.__name__.lower()}.svg"
-+        f"com.protonvpn.www.state-{states.Connected.__name__.lower()}"
-     )
-     CONNECTED_ICON_DESCRIPTION = str(
-         f"VPN {states.Connected.__name__.lower()}"
-     )
-     ERROR_ICON = str(
--        ICONS_PATH / f"state-{states.Error.__name__.lower()}.svg"
-+        f"com.protonvpn.www.state-{states.Error.__name__.lower()}"
-     )
-     ERROR_ICON_DESCRIPTION = str(
-         f"VPN {states.Error.__name__.lower()}"
+ def connect_once(widget: Gtk.Widget, signal: str, callback: Callable, *args):


### PR DESCRIPTION
https://github.com/flathub/com.protonvpn.www/issues/427 reports that a general tray icon image is used under KDE.

https://github.com/flathub/com.protonvpn.www/pull/423 removed the `org.kde.StatusNotifierItem` prefix from the tray icon bus name. However, it didn't drop the `org.kde.StatusNotifierItem` talk name permission, and removing that permission prevents the tray icon from showing up at all. That suggests the error in this approach. Therefore, this commit restores the prefix.

