### PR TITLE
Integrate proton-vpn-cli into Flatpak

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,36 @@ Copy
 - `~/.local/share/flatpak/app/com.protonvpn.www/current/active/export/share/applications/com.protonvpn.www.desktop` if Proton VPN is installed to the user
 
 to `~/.config/autostart/`.
+
+## Using the CLI
+
+The Proton VPN CLI is available in this Flatpak build.
+
+```bash
+# Show help
+flatpak run com.protonvpn.www protonvpn --help
+
+# Show connection status
+flatpak run com.protonvpn.www protonvpn status
+
+# Sign in and connect
+flatpak run com.protonvpn.www protonvpn signin
+flatpak run com.protonvpn.www protonvpn connect
+
+# Disconnect
+flatpak run com.protonvpn.www protonvpn disconnect
+```
+
+For convenience, add an alias in your shell profile:
+
+```bash
+alias protonvpn='flatpak run com.protonvpn.www protonvpn'
+```
+
+## Updating CLI dependencies
+
+When `proton-vpn-cli` updates runtime dependencies, regenerate the resources file with:
+
+```bash
+flatpak-pip-generator --checker-data --yaml --runtime='org.gnome.Sdk//49' click dbus-fast tabulate -o pip-resources.proton-vpn-cli
+```

--- a/com.protonvpn.www.yml
+++ b/com.protonvpn.www.yml
@@ -814,6 +814,22 @@ modules:
           dist: stable
           component: main
 
+  - name: proton-vpn-cli
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "." --no-build-isolation
+    modules:
+      # flatpak-pip-generator --checker-data --yaml --runtime='org.gnome.Sdk//49' "click" "dbus-fast" "tabulate" -o pip-resources.proton-vpn-cli
+      # https://github.com/ProtonVPN/proton-vpn-cli/blob/f00eb2a07e810f9563323bd38ee4a7bd3c3226c8/setup.py#L16-L23
+      - pip-resources.proton-vpn-cli.yaml
+    sources:
+      - type: git
+        url: https://github.com/ProtonVPN/proton-vpn-cli.git
+        tag: v1.0.0
+        commit: f00eb2a07e810f9563323bd38ee4a7bd3c3226c8
+        disable-submodules: true
+
   - name: proton-vpn-gtk-app
     buildsystem: simple
     build-commands:

--- a/pip-resources.proton-vpn-cli.yaml
+++ b/pip-resources.proton-vpn-cli.yaml
@@ -1,0 +1,43 @@
+# Generated with flatpak-pip-generator --checker-data --yaml --runtime=org.gnome.Sdk//49 click dbus-fast tabulate -o pip-resources.proton-vpn-cli
+build-commands: []
+buildsystem: simple
+modules:
+- name: python3-click
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+    --prefix=${FLATPAK_DEST} "click" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl
+    sha256: 1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d
+    x-checker-data:
+      name: click
+      packagetype: bdist_wheel
+      type: pypi
+- name: python3-dbus-fast
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+    --prefix=${FLATPAK_DEST} "dbus-fast" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/5f/cd/402b0e524bdf37d8b1d22b1d926c538bf1d2eedf115ea1d401c6c08a7d81/dbus_fast-4.0.4.tar.gz
+    sha256: 43137f0b73a7adbf7d5c0e9eb9d8d34df9e6e0aeafade2166e641c52dfe0a853
+    x-checker-data:
+      name: dbus_fast
+      type: pypi
+- name: python3-tabulate
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+    --prefix=${FLATPAK_DEST} "tabulate" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
+    sha256: f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3
+    x-checker-data:
+      name: tabulate
+      packagetype: bdist_wheel
+      type: pypi
+name: pip-resources.proton-vpn-cli


### PR DESCRIPTION
## Summary
- add a new proton-vpn-cli module to com.protonvpn.www.yml pinned to v1.0.0
- add pip-resources.proton-vpn-cli.yaml generated with flatpak-pip-generator
- document CLI invocation and dependency update workflow in README.md

## Test Plan
- [x] flatpak run org.flatpak.Builder build --ccache --disable-updates --force-clean --disable-rofiles-fuse --user --install com.protonvpn.www.yml
- [x] flatpak run org.flatpak.Builder --run build com.protonvpn.www.yml protonvpn --help
- [x] flatpak run --command=protonvpn com.protonvpn.www --help | head -n 25
