### PR TITLE
feat: Fedora-stable Flatpak dependency updater

### DIFF
--- a/.fedora-tracked-modules.yaml
+++ b/.fedora-tracked-modules.yaml
@@ -1,0 +1,266 @@
+modules:
+  NetworkManager:
+    recipe: git
+    fedora_package: NetworkManager
+    repo_url: https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git
+    tag_template: $version
+  NetworkManager-openvpn:
+    recipe: git
+    fedora_package: NetworkManager-openvpn
+    repo_url: https://github.com/NetworkManager/NetworkManager-openvpn.git
+    tag_template: $version
+  iproute2:
+    recipe: archive
+    fedora_package: iproute
+    url_template: 
+      https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-$version.tar.xz
+  libndp:
+    recipe: archive
+    fedora_package: libndp
+    url_template: https://github.com/jpirko/libndp/archive/v$version.tar.gz
+  libnma:
+    recipe: archive
+    fedora_package: libnma
+    url_template: 
+      https://gitlab.gnome.org/GNOME/libnma/-/archive/$version/libnma-$version.tar.gz
+  meson:
+    recipe: pypi
+    pypi_name: meson
+    fedora_package: meson
+  polkit:
+    recipe: archive
+    fedora_package: polkit
+    url_template: 
+      https://github.com/polkit-org/polkit/archive/refs/tags/$version.tar.gz
+  python-dbus:
+    recipe: archive
+    fedora_package: python3-dbus
+    url_template: 
+      https://dbus.freedesktop.org/releases/dbus-python/dbus-python-$version.tar.gz
+  python3-aiohappyeyeballs:
+    recipe: pypi
+    pypi_name: aiohappyeyeballs
+    fedora_package: python3-aiohappyeyeballs
+  python3-aiohttp:
+    recipe: pypi
+    pypi_name: aiohttp
+    fedora_package: python3-aiohttp
+  python3-aiosignal:
+    recipe: pypi
+    pypi_name: aiosignal
+    fedora_package: python3-aiosignal
+  python3-asn1crypto:
+    recipe: pypi
+    pypi_name: asn1crypto
+    fedora_package: python3-asn1crypto
+  python3-attrs:
+    recipe: pypi
+    pypi_name: attrs
+    fedora_package: python3-attrs
+  python3-bcrypt:
+    recipe: pypi
+    pypi_name: bcrypt
+    fedora_package: python3-bcrypt
+    manual_followup: bcrypt vendors Rust crate sources in 
+      bcrypt-cargo-sources.json. Re-run flatpak-cargo-generator against the new 
+      version's Cargo.lock before merging.
+  python3-cairo:
+    recipe: pypi
+    pypi_name: pycairo
+    fedora_package: python3-cairo
+  python3-certifi:
+    recipe: pypi
+    pypi_name: certifi
+    fedora_package: python3-certifi
+  python3-cffi:
+    recipe: pypi
+    pypi_name: cffi
+    fedora_package: python3-cffi
+  python3-charset-normalizer:
+    recipe: pypi
+    pypi_name: charset_normalizer
+    fedora_package: python3-charset-normalizer
+  python3-click:
+    recipe: pypi
+    pypi_name: click
+    fedora_package: python3-click
+  python3-cryptography:
+    recipe: pypi-multi-wheel
+    pypi_name: cryptography
+    fedora_package: python3-cryptography
+    wheel_arches:
+    - aarch64
+    - x86_64
+  python3-dbus-fast:
+    recipe: pypi
+    pypi_name: dbus_fast
+    fedora_package: python3-dbus-fast
+  python3-distro:
+    recipe: pypi
+    pypi_name: distro
+    fedora_package: python3-distro
+  python3-expandvars:
+    recipe: pypi
+    pypi_name: expandvars
+    fedora_package: python3-expandvars
+  python3-fido2:
+    recipe: pypi
+    pypi_name: fido2
+    fedora_package: python3-fido2
+  python3-flit-core:
+    recipe: pypi
+    pypi_name: flit_core
+    fedora_package: python3-flit-core
+  python3-frozenlist:
+    recipe: pypi
+    pypi_name: frozenlist
+    fedora_package: python3-frozenlist
+  python3-gobject:
+    recipe: pypi
+    pypi_name: pygobject
+    fedora_package: python3-gobject
+  python3-hatch-fancy-pypi-readme:
+    recipe: pypi
+    pypi_name: hatch_fancy_pypi_readme
+    fedora_package: python3-hatch-fancy-pypi-readme
+  python3-hatch-vcs:
+    recipe: pypi
+    pypi_name: hatch_vcs
+    fedora_package: python3-hatch-vcs
+  python3-hatchling:
+    recipe: pypi
+    pypi_name: hatchling
+    fedora_package: python3-hatchling
+  python3-idna:
+    recipe: pypi
+    pypi_name: idna
+    fedora_package: python3-idna
+  python3-jaraco-classes:
+    recipe: pypi
+    pypi_name: jaraco.classes
+    fedora_package: python3-jaraco-classes
+  python3-jaraco-context:
+    recipe: pypi
+    pypi_name: jaraco.context
+    fedora_package: python3-jaraco-context
+  python3-jaraco-functools:
+    recipe: pypi
+    pypi_name: jaraco_functools
+    fedora_package: python3-jaraco-functools
+  python3-jeepney:
+    recipe: pypi
+    pypi_name: jeepney
+    fedora_package: python3-jeepney
+  python3-keyring:
+    recipe: pypi
+    pypi_name: keyring
+    fedora_package: python3-keyring
+  python3-more-itertools:
+    recipe: pypi
+    pypi_name: more_itertools
+    fedora_package: python3-more-itertools
+  python3-multidict:
+    recipe: pypi
+    pypi_name: multidict
+    fedora_package: python3-multidict
+  python3-packaging:
+    recipe: pypi
+    pypi_name: packaging
+    fedora_package: python3-packaging
+  python3-pathspec:
+    recipe: pypi
+    pypi_name: pathspec
+    fedora_package: python3-pathspec
+  python3-pefile:
+    recipe: pypi
+    pypi_name: pefile
+    fedora_package: python3-pefile
+  python3-pluggy:
+    recipe: pypi
+    pypi_name: pluggy
+    fedora_package: python3-pluggy
+  python3-poetry-core:
+    recipe: pypi
+    pypi_name: poetry-core
+    fedora_package: python3-poetry-core
+  python3-propcache:
+    recipe: pypi
+    pypi_name: propcache
+    fedora_package: python3-propcache
+  python3-pycparser:
+    recipe: pypi
+    pypi_name: pycparser
+    fedora_package: python3-pycparser
+  python3-pynacl:
+    recipe: pypi
+    pypi_name: pynacl
+    fedora_package: python3-pynacl
+  python3-pyopenssl:
+    recipe: pypi
+    pypi_name: pyOpenSSL
+    fedora_package: python3-pyOpenSSL
+  python3-pyparsing:
+    recipe: pypi
+    pypi_name: pyparsing
+    fedora_package: python3-pyparsing
+  python3-python-gnupg:
+    recipe: pypi
+    pypi_name: python_gnupg
+    fedora_package: python3-gnupg
+  python3-pyxdg:
+    recipe: pypi
+    pypi_name: pyxdg
+    fedora_package: python3-pyxdg
+  python3-requests:
+    recipe: pypi
+    pypi_name: requests
+    fedora_package: python3-requests
+  python3-secretstorage:
+    recipe: pypi
+    pypi_name: secretstorage
+    fedora_package: python3-secretstorage
+  python3-semantic_version:
+    recipe: pypi
+    pypi_name: semantic_version
+    fedora_package: python3-semantic_version
+  python3-sentry-sdk:
+    recipe: pypi
+    pypi_name: sentry_sdk
+    fedora_package: python3-sentry-sdk
+  python3-setuptools-rust:
+    recipe: pypi
+    pypi_name: setuptools-rust
+    fedora_package: python3-setuptools-rust
+  python3-setuptools_scm:
+    recipe: pypi
+    pypi_name: setuptools_scm
+    fedora_package: python3-setuptools_scm
+  python3-tabulate:
+    recipe: pypi
+    pypi_name: tabulate
+    fedora_package: python3-tabulate
+  python3-tomli:
+    recipe: pypi
+    pypi_name: tomli
+    fedora_package: python3-tomli
+  python3-trove-classifiers:
+    recipe: pypi
+    pypi_name: trove_classifiers
+    fedora_package: python3-trove-classifiers
+  python3-typing-extensions:
+    recipe: pypi
+    pypi_name: typing_extensions
+    fedora_package: python3-typing-extensions
+  python3-urllib3:
+    recipe: pypi
+    pypi_name: urllib3
+    fedora_package: python3-urllib3
+  python3-yarl:
+    recipe: pypi
+    pypi_name: yarl
+    fedora_package: python3-yarl
+  systemd:
+    recipe: git
+    fedora_package: systemd
+    repo_url: https://github.com/systemd/systemd.git
+    tag_pattern: ^v([\d.]+)$

--- a/.fedora-tracked-modules.yaml
+++ b/.fedora-tracked-modules.yaml
@@ -12,8 +12,7 @@ modules:
   iproute2:
     recipe: archive
     fedora_package: iproute
-    url_template: 
-      https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-$version.tar.xz
+    url_template: https://github.com/iproute2/iproute2/archive/refs/tags/v$version.tar.gz
   libndp:
     recipe: archive
     fedora_package: libndp
@@ -36,7 +35,7 @@ modules:
     recipe: archive
     fedora_package: python3-dbus
     url_template: 
-      https://dbus.freedesktop.org/releases/dbus-python/dbus-python-$version.tar.gz
+      https://dbus.freedesktop.org/releases/dbus-python/dbus-python-$version.tar.xz
   python3-aiohappyeyeballs:
     recipe: pypi
     pypi_name: aiohappyeyeballs

--- a/.github/workflows/test-fedora-flatpak-updater.yml
+++ b/.github/workflows/test-fedora-flatpak-updater.yml
@@ -21,10 +21,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: "3.13"
 

--- a/.github/workflows/test-fedora-flatpak-updater.yml
+++ b/.github/workflows/test-fedora-flatpak-updater.yml
@@ -1,0 +1,35 @@
+# .github/workflows/test-fedora-flatpak-updater.yml
+name: Test fedora_flatpak_updater
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "scripts/fedora_flatpak_updater/**"
+      - "tests/fedora_flatpak_updater/**"
+      - ".github/workflows/test-fedora-flatpak-updater.yml"
+  pull_request:
+    paths:
+      - "scripts/fedora_flatpak_updater/**"
+      - "tests/fedora_flatpak_updater/**"
+      - ".github/workflows/test-fedora-flatpak-updater.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+
+      - name: Sync fedora_flatpak_updater environment
+        run: uv sync --project scripts/fedora_flatpak_updater
+
+      - name: Run test suite
+        run: uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater -v

--- a/.github/workflows/test-fedora-flatpak-updater.yml
+++ b/.github/workflows/test-fedora-flatpak-updater.yml
@@ -21,10 +21,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.3.0
         with:
           python-version: "3.13"
 

--- a/.github/workflows/update-fedora-flatpak-deps.yml
+++ b/.github/workflows/update-fedora-flatpak-deps.yml
@@ -1,0 +1,50 @@
+# .github/workflows/update-fedora-flatpak-deps.yml
+name: Update Fedora-stable Flatpak dependencies
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # every Monday at 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+
+      - name: Sync fedora_flatpak_updater environment
+        run: uv sync --project scripts/fedora_flatpak_updater
+
+      - name: Run updater
+        run: |
+          uv run --project scripts/fedora_flatpak_updater python -m fedora_flatpak_updater.cli \
+            --mapping .fedora-tracked-modules.yaml \
+            --manifest com.protonvpn.www.yml | tee summary.md
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open pull request
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore: update Flatpak dependencies to Fedora-stable versions"
+          title: "chore: update Flatpak dependencies to Fedora-stable versions"
+          body-path: summary.md
+          branch: fedora-stable-flatpak-deps-update
+          delete-branch: true

--- a/.github/workflows/update-fedora-flatpak-deps.yml
+++ b/.github/workflows/update-fedora-flatpak-deps.yml
@@ -13,11 +13,12 @@ permissions:
 jobs:
   update:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: "3.13"
 
@@ -41,7 +42,7 @@ jobs:
 
       - name: Open pull request
         if: steps.diff.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8.1.1
         with:
           commit-message: "chore: update Flatpak dependencies to Fedora-stable versions"
           title: "chore: update Flatpak dependencies to Fedora-stable versions"

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ build-dir
 repo
 
 # End of https://www.toptal.com/developers/gitignore/api/flatpak
+
+### Python (fedora_flatpak_updater) ###
+scripts/fedora_flatpak_updater/.venv
+**/__pycache__/
+.pytest_cache

--- a/bcrypt-cargo-sources.json
+++ b/bcrypt-cargo-sources.json
@@ -2,14 +2,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/autocfg/autocfg-1.5.0.crate",
-        "sha256": "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8",
-        "dest": "cargo/vendor/autocfg-1.5.0"
+        "url": "https://static.crates.io/crates/autocfg/autocfg-1.4.0.crate",
+        "sha256": "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26",
+        "dest": "cargo/vendor/autocfg-1.4.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8\", \"files\": {}}",
-        "dest": "cargo/vendor/autocfg-1.5.0",
+        "contents": "{\"package\": \"ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26\", \"files\": {}}",
+        "dest": "cargo/vendor/autocfg-1.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -28,14 +28,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/bcrypt/bcrypt-0.17.1.crate",
-        "sha256": "abaf6da45c74385272ddf00e1ac074c7d8a6c1a1dda376902bd6a427522a8b2c",
-        "dest": "cargo/vendor/bcrypt-0.17.1"
+        "url": "https://static.crates.io/crates/bcrypt/bcrypt-0.17.0.crate",
+        "sha256": "92758ad6077e4c76a6cadbce5005f666df70d4f13b19976b1a8062eef880040f",
+        "dest": "cargo/vendor/bcrypt-0.17.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"abaf6da45c74385272ddf00e1ac074c7d8a6c1a1dda376902bd6a427522a8b2c\", \"files\": {}}",
-        "dest": "cargo/vendor/bcrypt-0.17.1",
+        "contents": "{\"package\": \"92758ad6077e4c76a6cadbce5005f666df70d4f13b19976b1a8062eef880040f\", \"files\": {}}",
+        "dest": "cargo/vendor/bcrypt-0.17.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -49,6 +49,19 @@
         "type": "inline",
         "contents": "{\"package\": \"6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2\", \"files\": {}}",
         "dest": "cargo/vendor/bcrypt-pbkdf-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bitflags/bitflags-2.8.0.crate",
+        "sha256": "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36",
+        "dest": "cargo/vendor/bitflags-2.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36\", \"files\": {}}",
+        "dest": "cargo/vendor/bitflags-2.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -93,14 +106,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cfg-if/cfg-if-1.0.3.crate",
-        "sha256": "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9",
-        "dest": "cargo/vendor/cfg-if-1.0.3"
+        "url": "https://static.crates.io/crates/cfg-if/cfg-if-1.0.0.crate",
+        "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+        "dest": "cargo/vendor/cfg-if-1.0.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9\", \"files\": {}}",
-        "dest": "cargo/vendor/cfg-if-1.0.3",
+        "contents": "{\"package\": \"baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg-if-1.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -171,14 +184,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/getrandom/getrandom-0.3.3.crate",
-        "sha256": "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4",
-        "dest": "cargo/vendor/getrandom-0.3.3"
+        "url": "https://static.crates.io/crates/getrandom/getrandom-0.3.1.crate",
+        "sha256": "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8",
+        "dest": "cargo/vendor/getrandom-0.3.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4\", \"files\": {}}",
-        "dest": "cargo/vendor/getrandom-0.3.3",
+        "contents": "{\"package\": \"43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8\", \"files\": {}}",
+        "dest": "cargo/vendor/getrandom-0.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -197,14 +210,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/indoc/indoc-2.0.6.crate",
-        "sha256": "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd",
-        "dest": "cargo/vendor/indoc-2.0.6"
+        "url": "https://static.crates.io/crates/indoc/indoc-2.0.5.crate",
+        "sha256": "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5",
+        "dest": "cargo/vendor/indoc-2.0.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd\", \"files\": {}}",
-        "dest": "cargo/vendor/indoc-2.0.6",
+        "contents": "{\"package\": \"b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5\", \"files\": {}}",
+        "dest": "cargo/vendor/indoc-2.0.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -223,14 +236,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/libc/libc-0.2.176.crate",
-        "sha256": "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174",
-        "dest": "cargo/vendor/libc-0.2.176"
+        "url": "https://static.crates.io/crates/libc/libc-0.2.170.crate",
+        "sha256": "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828",
+        "dest": "cargo/vendor/libc-0.2.170"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174\", \"files\": {}}",
-        "dest": "cargo/vendor/libc-0.2.176",
+        "contents": "{\"package\": \"875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828\", \"files\": {}}",
+        "dest": "cargo/vendor/libc-0.2.170",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -249,14 +262,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/once_cell/once_cell-1.21.3.crate",
-        "sha256": "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d",
-        "dest": "cargo/vendor/once_cell-1.21.3"
+        "url": "https://static.crates.io/crates/once_cell/once_cell-1.20.3.crate",
+        "sha256": "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e",
+        "dest": "cargo/vendor/once_cell-1.20.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d\", \"files\": {}}",
-        "dest": "cargo/vendor/once_cell-1.21.3",
+        "contents": "{\"package\": \"945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e\", \"files\": {}}",
+        "dest": "cargo/vendor/once_cell-1.20.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -275,131 +288,118 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/portable-atomic/portable-atomic-1.11.1.crate",
-        "sha256": "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483",
-        "dest": "cargo/vendor/portable-atomic-1.11.1"
+        "url": "https://static.crates.io/crates/portable-atomic/portable-atomic-1.11.0.crate",
+        "sha256": "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e",
+        "dest": "cargo/vendor/portable-atomic-1.11.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483\", \"files\": {}}",
-        "dest": "cargo/vendor/portable-atomic-1.11.1",
+        "contents": "{\"package\": \"350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e\", \"files\": {}}",
+        "dest": "cargo/vendor/portable-atomic-1.11.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.101.crate",
-        "sha256": "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de",
-        "dest": "cargo/vendor/proc-macro2-1.0.101"
+        "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.93.crate",
+        "sha256": "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99",
+        "dest": "cargo/vendor/proc-macro2-1.0.93"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de\", \"files\": {}}",
-        "dest": "cargo/vendor/proc-macro2-1.0.101",
+        "contents": "{\"package\": \"60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro2-1.0.93",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pyo3/pyo3-0.26.0.crate",
-        "sha256": "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383",
-        "dest": "cargo/vendor/pyo3-0.26.0"
+        "url": "https://static.crates.io/crates/pyo3/pyo3-0.23.5.crate",
+        "sha256": "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872",
+        "dest": "cargo/vendor/pyo3-0.23.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383\", \"files\": {}}",
-        "dest": "cargo/vendor/pyo3-0.26.0",
+        "contents": "{\"package\": \"7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872\", \"files\": {}}",
+        "dest": "cargo/vendor/pyo3-0.23.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pyo3-build-config/pyo3-build-config-0.26.0.crate",
-        "sha256": "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f",
-        "dest": "cargo/vendor/pyo3-build-config-0.26.0"
+        "url": "https://static.crates.io/crates/pyo3-build-config/pyo3-build-config-0.23.5.crate",
+        "sha256": "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb",
+        "dest": "cargo/vendor/pyo3-build-config-0.23.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f\", \"files\": {}}",
-        "dest": "cargo/vendor/pyo3-build-config-0.26.0",
+        "contents": "{\"package\": \"94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb\", \"files\": {}}",
+        "dest": "cargo/vendor/pyo3-build-config-0.23.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pyo3-ffi/pyo3-ffi-0.26.0.crate",
-        "sha256": "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105",
-        "dest": "cargo/vendor/pyo3-ffi-0.26.0"
+        "url": "https://static.crates.io/crates/pyo3-ffi/pyo3-ffi-0.23.5.crate",
+        "sha256": "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d",
+        "dest": "cargo/vendor/pyo3-ffi-0.23.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105\", \"files\": {}}",
-        "dest": "cargo/vendor/pyo3-ffi-0.26.0",
+        "contents": "{\"package\": \"e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d\", \"files\": {}}",
+        "dest": "cargo/vendor/pyo3-ffi-0.23.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pyo3-macros/pyo3-macros-0.26.0.crate",
-        "sha256": "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded",
-        "dest": "cargo/vendor/pyo3-macros-0.26.0"
+        "url": "https://static.crates.io/crates/pyo3-macros/pyo3-macros-0.23.5.crate",
+        "sha256": "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da",
+        "dest": "cargo/vendor/pyo3-macros-0.23.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded\", \"files\": {}}",
-        "dest": "cargo/vendor/pyo3-macros-0.26.0",
+        "contents": "{\"package\": \"fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da\", \"files\": {}}",
+        "dest": "cargo/vendor/pyo3-macros-0.23.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pyo3-macros-backend/pyo3-macros-backend-0.26.0.crate",
-        "sha256": "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf",
-        "dest": "cargo/vendor/pyo3-macros-backend-0.26.0"
+        "url": "https://static.crates.io/crates/pyo3-macros-backend/pyo3-macros-backend-0.23.5.crate",
+        "sha256": "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028",
+        "dest": "cargo/vendor/pyo3-macros-backend-0.23.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf\", \"files\": {}}",
-        "dest": "cargo/vendor/pyo3-macros-backend-0.26.0",
+        "contents": "{\"package\": \"fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028\", \"files\": {}}",
+        "dest": "cargo/vendor/pyo3-macros-backend-0.23.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/quote/quote-1.0.40.crate",
-        "sha256": "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d",
-        "dest": "cargo/vendor/quote-1.0.40"
+        "url": "https://static.crates.io/crates/quote/quote-1.0.38.crate",
+        "sha256": "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc",
+        "dest": "cargo/vendor/quote-1.0.38"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d\", \"files\": {}}",
-        "dest": "cargo/vendor/quote-1.0.40",
+        "contents": "{\"package\": \"0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc\", \"files\": {}}",
+        "dest": "cargo/vendor/quote-1.0.38",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/r-efi/r-efi-5.3.0.crate",
-        "sha256": "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f",
-        "dest": "cargo/vendor/r-efi-5.3.0"
+        "url": "https://static.crates.io/crates/sha2/sha2-0.10.8.crate",
+        "sha256": "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8",
+        "dest": "cargo/vendor/sha2-0.10.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f\", \"files\": {}}",
-        "dest": "cargo/vendor/r-efi-5.3.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/sha2/sha2-0.10.9.crate",
-        "sha256": "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283",
-        "dest": "cargo/vendor/sha2-0.10.9"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283\", \"files\": {}}",
-        "dest": "cargo/vendor/sha2-0.10.9",
+        "contents": "{\"package\": \"793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8\", \"files\": {}}",
+        "dest": "cargo/vendor/sha2-0.10.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -418,27 +418,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/syn/syn-2.0.106.crate",
-        "sha256": "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6",
-        "dest": "cargo/vendor/syn-2.0.106"
+        "url": "https://static.crates.io/crates/syn/syn-2.0.98.crate",
+        "sha256": "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1",
+        "dest": "cargo/vendor/syn-2.0.98"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6\", \"files\": {}}",
-        "dest": "cargo/vendor/syn-2.0.106",
+        "contents": "{\"package\": \"36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1\", \"files\": {}}",
+        "dest": "cargo/vendor/syn-2.0.98",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/target-lexicon/target-lexicon-0.13.3.crate",
-        "sha256": "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c",
-        "dest": "cargo/vendor/target-lexicon-0.13.3"
+        "url": "https://static.crates.io/crates/target-lexicon/target-lexicon-0.12.16.crate",
+        "sha256": "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1",
+        "dest": "cargo/vendor/target-lexicon-0.12.16"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c\", \"files\": {}}",
-        "dest": "cargo/vendor/target-lexicon-0.13.3",
+        "contents": "{\"package\": \"61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1\", \"files\": {}}",
+        "dest": "cargo/vendor/target-lexicon-0.12.16",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -457,27 +457,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unicode-ident/unicode-ident-1.0.19.crate",
-        "sha256": "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d",
-        "dest": "cargo/vendor/unicode-ident-1.0.19"
+        "url": "https://static.crates.io/crates/unicode-ident/unicode-ident-1.0.17.crate",
+        "sha256": "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe",
+        "dest": "cargo/vendor/unicode-ident-1.0.17"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d\", \"files\": {}}",
-        "dest": "cargo/vendor/unicode-ident-1.0.19",
+        "contents": "{\"package\": \"00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-ident-1.0.17",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unindent/unindent-0.2.4.crate",
-        "sha256": "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3",
-        "dest": "cargo/vendor/unindent-0.2.4"
+        "url": "https://static.crates.io/crates/unindent/unindent-0.2.3.crate",
+        "sha256": "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce",
+        "dest": "cargo/vendor/unindent-0.2.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3\", \"files\": {}}",
-        "dest": "cargo/vendor/unindent-0.2.4",
+        "contents": "{\"package\": \"c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce\", \"files\": {}}",
+        "dest": "cargo/vendor/unindent-0.2.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -496,40 +496,144 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasi/wasi-0.14.7+wasi-0.2.4.crate",
-        "sha256": "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c",
-        "dest": "cargo/vendor/wasi-0.14.7+wasi-0.2.4"
+        "url": "https://static.crates.io/crates/wasi/wasi-0.13.3+wasi-0.2.2.crate",
+        "sha256": "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2",
+        "dest": "cargo/vendor/wasi-0.13.3+wasi-0.2.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c\", \"files\": {}}",
-        "dest": "cargo/vendor/wasi-0.14.7+wasi-0.2.4",
+        "contents": "{\"package\": \"26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2\", \"files\": {}}",
+        "dest": "cargo/vendor/wasi-0.13.3+wasi-0.2.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasip2/wasip2-1.0.1+wasi-0.2.4.crate",
-        "sha256": "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7",
-        "dest": "cargo/vendor/wasip2-1.0.1+wasi-0.2.4"
+        "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.52.6.crate",
+        "sha256": "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973",
+        "dest": "cargo/vendor/windows-targets-0.52.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7\", \"files\": {}}",
-        "dest": "cargo/vendor/wasip2-1.0.1+wasi-0.2.4",
+        "contents": "{\"package\": \"9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-targets-0.52.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wit-bindgen/wit-bindgen-0.46.0.crate",
-        "sha256": "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59",
-        "dest": "cargo/vendor/wit-bindgen-0.46.0"
+        "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.52.6.crate",
+        "sha256": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59\", \"files\": {}}",
-        "dest": "cargo/vendor/wit-bindgen-0.46.0",
+        "contents": "{\"package\": \"32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.52.6.crate",
+        "sha256": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.52.6.crate",
+        "sha256": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b",
+        "dest": "cargo/vendor/windows_i686_gnu-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnu-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_gnullvm/windows_i686_gnullvm-0.52.6.crate",
+        "sha256": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66",
+        "dest": "cargo/vendor/windows_i686_gnullvm-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnullvm-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.52.6.crate",
+        "sha256": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66",
+        "dest": "cargo/vendor/windows_i686_msvc-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_msvc-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.52.6.crate",
+        "sha256": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.52.6.crate",
+        "sha256": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.52.6.crate",
+        "sha256": "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wit-bindgen-rt/wit-bindgen-rt-0.33.0.crate",
+        "sha256": "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c",
+        "dest": "cargo/vendor/wit-bindgen-rt-0.33.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c\", \"files\": {}}",
+        "dest": "cargo/vendor/wit-bindgen-rt-0.33.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/com.protonvpn.www.yml
+++ b/com.protonvpn.www.yml
@@ -5,823 +5,659 @@ runtime: org.gnome.Platform
 runtime-version: '50'
 sdk: org.gnome.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.rust-stable
+- org.freedesktop.Sdk.Extension.rust-stable
 command: protonvpn-app
 finish-args:
-  - --share=ipc
-  - --share=network
-  - --socket=wayland
-  - --socket=fallback-x11
+- --share=ipc
+- --share=network
+- --socket=wayland
+- --socket=fallback-x11
   # To store credentials
-  - --talk-name=org.freedesktop.secrets
+- --talk-name=org.freedesktop.secrets
   # To check the Network Manager status on the host system
-  - --system-talk-name=org.freedesktop.NetworkManager
+- --system-talk-name=org.freedesktop.NetworkManager
   # The downloaded OpenVPN profile hardcodes the certificate path
-  - --filesystem=~/.cert/nm-openvpn/
+- --filesystem=~/.cert/nm-openvpn/
   # In case ~/.cert is not created
-  - --filesystem=~/.cert:create
+- --filesystem=~/.cert:create
   # For bug report
-  - --filesystem=/var/log/journal:ro
+- --filesystem=/var/log/journal:ro
   # For DBus daemon reconnector
-  - --system-talk-name=org.freedesktop.login1
+- --system-talk-name=org.freedesktop.login1
   # New dbus session name
-  - --own-name=proton.vpn.app.gtk
+- --own-name=proton.vpn.app.gtk
   # Tray icon
-  - --talk-name=org.kde.StatusNotifierWatcher
+- --talk-name=org.kde.StatusNotifierWatcher
     # Fido2 USB security keys
-  - --device=all
+- --device=all
 
 modules:
-  - shared-modules/intltool/intltool-0.51.json
+- shared-modules/intltool/intltool-0.51.json
 
-  - name: python3-packaging
+- name: python3-packaging
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "packaging" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl
+    sha256: 29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484
+  modules:
+  - name: python3-toml
     buildsystem: simple
     build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "packaging" --no-build-isolation
+    - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "toml" --no-build-isolation
     sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
-        sha256: 5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e
-        x-checker-data:
-          name: packaging
-          packagetype: bdist_wheel
-          type: pypi
-    modules:
-      - name: python3-toml
-        buildsystem: simple
-        build-commands:
-          - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-            --prefix=${FLATPAK_DEST} "toml" --no-build-isolation
-        sources:
-          - type: file
-            url: https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz
-            sha256: b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
-            x-checker-data:
-              type: pypi
-              name: toml
+    - type: file
+      url: https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz
+      sha256: b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
+      x-checker-data:
+        type: pypi
+        name: toml
 
   # Required by OpenSSL/crypto.py at runtime
-  - name: python-typing-extensions
+- name: python-typing-extensions
+  buildsystem: simple
+  build-commands:
+  - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" .
+  sources:
+  - type: archive
+    url: https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz
+    sha256: 0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466
+  modules:
+  - name: python3-flit_core
     buildsystem: simple
+    cleanup: ['*']
     build-commands:
-      - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" .
+    - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "flit_core" --no-build-isolation
     sources:
-      - type: archive
-        url: https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz
-        sha256: 0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466
-        x-checker-data:
-          type: pypi
-          name: typing_extensions
-    modules:
-      - name: python3-flit_core
-        buildsystem: simple
-        cleanup: ['*']
-        build-commands:
-          - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-            --prefix=${FLATPAK_DEST} "flit_core" --no-build-isolation
-        sources:
-          - type: file
-            url: https://files.pythonhosted.org/packages/69/59/b6fc2188dfc7ea4f936cd12b49d707f66a1cb7a1d2c16172963534db741b/flit_core-3.12.0.tar.gz
-            sha256: 18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2
-            x-checker-data:
-              type: pypi
-              name: flit_core
+    - type: file
+      url: https://files.pythonhosted.org/packages/69/59/b6fc2188dfc7ea4f936cd12b49d707f66a1cb7a1d2c16172963534db741b/flit_core-3.12.0.tar.gz
+      sha256: 18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2
 
   # The bcrypt Python library is handled specially since it has Rust code and dependencies.
   # The cryptography Python library is handled specially since it has Rust code and dependencies.
-  - name: python3-bcrypt
-    build-options:
-      append-path: /usr/lib/sdk/rust-stable/bin
-      env:
-        CARGO_HOME: /run/build/python3-bcrypt/cargo
-        CARGO_NET_OFFLINE: 'true'
-        RUST_BACKTRACE: '1'
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "bcrypt" --no-build-isolation
-    modules:
+- name: python3-bcrypt
+  build-options:
+    append-path: /usr/lib/sdk/rust-stable/bin
+    env:
+      CARGO_HOME: /run/build/python3-bcrypt/cargo
+      CARGO_NET_OFFLINE: 'true'
+      RUST_BACKTRACE: '1'
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "bcrypt" --no-build-isolation
+  modules:
       # Python dependencies required to build things
       # https://github.com/flathub/org.thonny.Thonny/blob/2f10b0123b1df4111c4c4fb3277fdebab56c7e73/org.thonny.Thonny.yaml#L75-L234
 
-      - name: python3-flit_core
-        buildsystem: simple
-        cleanup: ['*']
-        build-commands:
-          - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-            --prefix=${FLATPAK_DEST} "flit_core" --no-build-isolation
-        sources:
-          - type: file
-            url: https://files.pythonhosted.org/packages/69/59/b6fc2188dfc7ea4f936cd12b49d707f66a1cb7a1d2c16172963534db741b/flit_core-3.12.0.tar.gz
-            sha256: 18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2
-            x-checker-data:
-              type: pypi
-              name: flit_core
-      - name: python3-poetry-core
-        buildsystem: simple
-        cleanup: ['*']
-        build-commands:
-          - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-            --prefix=${FLATPAK_DEST} "poetry-core" --no-build-isolation
-        sources:
-          - type: file
-            url: https://files.pythonhosted.org/packages/b2/f2/fa88c58efb9a737c7e0e40e470edd0973fe33f0f277d24dcf17454b50974/poetry_core-2.4.1.tar.gz
-            sha256: 89dceb6c10e9c6d8650a16183400e3c9ff9ddee13b0a81023b5575334a2b3744
-            x-checker-data:
-              type: pypi
-              name: poetry-core
-      - name: python3-setuptools_scm
-        buildsystem: simple
-        cleanup: ['*']
-        build-commands:
-          - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-            --prefix=${FLATPAK_DEST} "setuptools_scm" --no-build-isolation
-        sources:
-          - type: file
-            url: https://files.pythonhosted.org/packages/e6/60/73603fbcdbe5e803855bcce4414f94eaeed449083bd8183e67161af78188/vcs_versioning-1.1.1-py3-none-any.whl
-            sha256: b541e2ba79fc6aaa3850f8a7f88af43d97c1c80649c01142ee4146eddbc599e4
-            x-checker-data:
-              name: vcs-versioning
-              packagetype: bdist_wheel
-              type: pypi
-          - type: file
-            url: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
-            sha256: 850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d
-            x-checker-data:
-              name: pyparsing
-              packagetype: bdist_wheel
-              type: pypi
-          - type: file
-            url: https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl
-            sha256: 0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe
-            x-checker-data:
-              name: tomli
-              packagetype: bdist_wheel
-              type: pypi
-          - type: file
-            url: https://files.pythonhosted.org/packages/5c/e1/342c4434df56aa537f6ce7647eefee521d96fbb828b08acd709865767652/setuptools_scm-10.0.5-py3-none-any.whl
-            sha256: f611037d8aae618221503b8fa89319f073438252ae3420e01c9ceec249131a0a
-            x-checker-data:
-              name: setuptools_scm
-              packagetype: bdist_wheel
-              type: pypi
-      - name: python3-setuptools_rust
-        buildsystem: simple
-        cleanup: ['*']
-        build-commands:
-          - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-            --prefix=${FLATPAK_DEST} "setuptools_rust" --no-build-isolation
-        sources:
-          - type: file
-            url: https://files.pythonhosted.org/packages/7d/31/f2289ce78b9b473d582568c234e104d2a342fd658cc288a7553d83bb8595/semantic_version-2.10.0.tar.gz
-            sha256: bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c
-            x-checker-data:
-              type: pypi
-              name: semantic_version
-          - type: file
-            url: https://files.pythonhosted.org/packages/0c/11/736cfe4ec795dbce001ebdcef5cab03de1727041c805c3a45c1bda9f54a1/setuptools_rust-1.12.1.tar.gz
-            sha256: 85ae70989d96c9cfeb5ef79cf3bac2d5200bc5564f720a06edceedbdf6664640
-            x-checker-data:
-              type: pypi
-              name: setuptools-rust
+  - name: python3-flit_core
+    buildsystem: simple
+    cleanup: ['*']
+    build-commands:
+    - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "flit_core" --no-build-isolation
     sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz
-        sha256: f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd
-        x-checker-data:
-          type: pypi
-          name: bcrypt
+    - type: file
+      url: https://files.pythonhosted.org/packages/69/59/b6fc2188dfc7ea4f936cd12b49d707f66a1cb7a1d2c16172963534db741b/flit_core-3.12.0.tar.gz
+      sha256: 18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2
+  - name: python3-poetry-core
+    buildsystem: simple
+    cleanup: ['*']
+    build-commands:
+    - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "poetry-core" --no-build-isolation
+    sources:
+    - type: file
+      url: https://files.pythonhosted.org/packages/e9/2a/457e29bd71c4fdce5dbd032ad02cb80300db355d084cd3fa81a367d22f0c/poetry_core-2.3.0.tar.gz
+      sha256: f6da8f021fe380d8c9716085f4dcc5d26a5120a2452e077196333892af5de307
+  - name: python3-setuptools_scm
+    buildsystem: simple
+    cleanup: ['*']
+    build-commands:
+    - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "setuptools_scm" --no-build-isolation
+    sources:
+    - type: file
+      url: https://files.pythonhosted.org/packages/e6/60/73603fbcdbe5e803855bcce4414f94eaeed449083bd8183e67161af78188/vcs_versioning-1.1.1-py3-none-any.whl
+      sha256: b541e2ba79fc6aaa3850f8a7f88af43d97c1c80649c01142ee4146eddbc599e4
+      x-checker-data:
+        name: vcs-versioning
+        packagetype: bdist_wheel
+        type: pypi
+    - type: file
+      url: https://files.pythonhosted.org/packages/9d/ea/6d76df31432a0e6fdf81681a895f009a4bb47b3c39036db3e1b528191d52/pyparsing-3.1.2-py3-none-any.whl
+      sha256: f9db75911801ed778fe61bb643079ff86601aca99fcae6345aa67292038fb742
+    - type: file
+      url: https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl
+      sha256: f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30
+    - type: file
+      url: https://files.pythonhosted.org/packages/3d/ea/ac2bf868899d0d2e82ef72d350d97a846110c709bacf2d968431576ca915/setuptools_scm-9.2.2-py3-none-any.whl
+      sha256: 30e8f84d2ab1ba7cb0e653429b179395d0c33775d54807fc5f1dd6671801aef7
+  - name: python3-setuptools_rust
+    buildsystem: simple
+    cleanup: ['*']
+    build-commands:
+    - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "setuptools_rust" --no-build-isolation
+    sources:
+    - type: file
+      url: https://files.pythonhosted.org/packages/7d/31/f2289ce78b9b473d582568c234e104d2a342fd658cc288a7553d83bb8595/semantic_version-2.10.0.tar.gz
+      sha256: bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c
+    - type: file
+      url: https://files.pythonhosted.org/packages/68/ba/b31781d61bf9ee3c232a1d1160db11c11cdeae1d44e06c90723b25a8279f/setuptools_rust-1.13.0.tar.gz
+      sha256: f2afcf4baeee689910ce49cfa8aad4e08cce72f417449bcc32891b8664fdc726
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/bb/5d/6d7433e0f3cd46ce0b43cd65e1db465ea024dbb8216fb2404e919c2ad77b/bcrypt-4.3.0.tar.gz
+    sha256: 3a3fd2204178b6d2adcf09cb4f6426ffef54762577a7c9b54c159008cb288c18
       # The Cargo sources should be updated whenever bcrypt is updated.
       # wget https://raw.githubusercontent.com/pyca/bcrypt/refs/tags/5.0.0/src/_bcrypt/Cargo.lock -O /tmp/Cargo.lock
       # python flatpak-builder-tools/cargo/flatpak-cargo-generator.py -o bcrypt-cargo-sources.json /tmp/Cargo.lock
-      - bcrypt-cargo-sources.json
+  - bcrypt-cargo-sources.json
 
-  - name: libndp
-    buildsystem: autotools
-    cleanup:
-      - /bin
-      - /include
-      - /lib/pkgconfig
-      - /share/man
-    sources:
-      - type: archive
-        url: https://github.com/jpirko/libndp/archive/v1.9.tar.gz
-        sha256: e564f5914a6b1b799c3afa64c258824a801c1b79a29e2fe6525b682249c65261
-        x-checker-data:
-          type: anitya
-          project-id: 14944
-          stable-only: true
-          url-template: https://github.com/jpirko/libndp/archive/v$version.tar.gz
+- name: libndp
+  buildsystem: autotools
+  cleanup:
+  - /bin
+  - /include
+  - /lib/pkgconfig
+  - /share/man
+  sources:
+  - type: archive
+    url: https://github.com/jpirko/libndp/archive/v1.9.tar.gz
+    sha256: e564f5914a6b1b799c3afa64c258824a801c1b79a29e2fe6525b682249c65261
 
   # https://github.com/flathub/com.anydesk.Anydesk/blob/f06549a3749ecbcc99cbbfd7753bfa884746b404/com.anydesk.Anydesk.json#L84-L115
-  - name: polkit
-    buildsystem: meson
-    config-opts:
-      - -Dlibs-only=true
-      - -Dman=false
-      - -Dintrospection=false
-      - -Dexamples=false
-      - -Dgtk_doc=false
-      - -Dauthfw=shadow
-    cleanup:
-      - /bin/*
-      - /etc/pam.d
-      - /etc/dbus-1
-      - /share/dbus-1/system-services/*
-      - /share/polkit-1
-      - /share/polkit-1/actions/*
-      - /lib/polkit-1
-      - /include
-    sources:
-      - x-checker-data:
-          type: anitya
-          project-id: 3682
-          url-template: >-
-            https://gitlab.freedesktop.org/polkit/polkit/-/archive/$version/polkit-$version.tar.gz
-        type: archive
-        url: >-
-          https://gitlab.freedesktop.org/polkit/polkit/-/archive/124/polkit-124.tar.gz
-        sha256: 72457d96a0538fd03a3ca96a6bf9b7faf82184d4d67c793eb759168e4fd49e20
+- name: polkit
+  buildsystem: meson
+  config-opts:
+  - -Dlibs-only=true
+  - -Dman=false
+  - -Dintrospection=false
+  - -Dexamples=false
+  - -Dgtk_doc=false
+  - -Dauthfw=shadow
+  cleanup:
+  - /bin/*
+  - /etc/pam.d
+  - /etc/dbus-1
+  - /share/dbus-1/system-services/*
+  - /share/polkit-1
+  - /share/polkit-1/actions/*
+  - /lib/polkit-1
+  - /include
+  sources:
+  - type: archive
+    url: >-
+      https://github.com/polkit-org/polkit/archive/refs/tags/127.tar.gz
+    sha256: 9b7bc16f086479dcc626c575976568ba4a85d34297a750d8ab3d2e57f6d8b988
 
   # https://github.com/flathub/org.gnome.NetworkDisplays/blob/5a3369d04e32ccd092e42463de5171f473a8601d/org.gnome.NetworkDisplays.json#LL177C11-L230C11
-  - name: NetworkManager
-    buildsystem: meson
-    build-options:
-      cflags: -ltinfo
-      cxxflags: -ltinfo
-    config-opts:
-      - -Dsystemdsystemunitdir=no
-      - -Ddbus_conf_dir=/app/etc/dbus-1/system.d
-      - -Diptables=/usr/bin/true
-      - -Ddnsmasq=/usr/bin/true
-      - -Dsession_tracking=no
-      - -Dselinux=false
-      - -Dsystemd_journal=false
-      - -Dlibaudit=no
-      - -Dwext=false
-      - -Dwifi=false
-      - -Dppp=false
-      - -Dmodem_manager=false
-      - -Dovs=false
-      - -Dnmcli=false
-      - -Dnmtui=false
+- name: NetworkManager
+  buildsystem: meson
+  build-options:
+    cflags: -ltinfo
+    cxxflags: -ltinfo
+  config-opts:
+  - -Dsystemdsystemunitdir=no
+  - -Ddbus_conf_dir=/app/etc/dbus-1/system.d
+  - -Diptables=/usr/bin/true
+  - -Ddnsmasq=/usr/bin/true
+  - -Dsession_tracking=no
+  - -Dselinux=false
+  - -Dsystemd_journal=false
+  - -Dlibaudit=no
+  - -Dwext=false
+  - -Dwifi=false
+  - -Dppp=false
+  - -Dmodem_manager=false
+  - -Dovs=false
+  - -Dnmcli=false
+  - -Dnmtui=false
       # We need introspection
-      - -Dintrospection=true
-      - -Dvapi=false
-      - -Ddocs=false
-      - -Dtests=no
-      - -Dfirewalld_zone=false
-      - -Dlibpsl=false
-      - -Dqt=false
-    cleanup:
-      - /sbin
-      - /etc
-      - /include
-      - /lib/pkgconfig
-      - /libexec
-      - /var
-      - /share/bash-completion
-      - /share/doc
-    sources:
-      - type: git
-        url: https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git
-        tag: 1.40.18
-        commit: 2db3748ec8162ce948ba52f71b42a258ff8d64ba
-        x-checker-data:
-          type: anitya
-          project-id: 21197
-          stable-only: true
-          tag-template: $version
-          versions:
-            # Breaking change in 1.42.x: `dns` will be replaced by `dns-data`, which is incompatible with older NetworkManager on the host system
-            <: 1.42.0
-
-      # To fix `Support for given configuration is not implemented` when trying to connect: https://github.com/flathub/com.protonvpn.www/issues/2
-      # Copied from https://github.com/flathub/com.github.jkotra.eovpn/blob/670f19e2aee1c9559fbe4eed904e35500843ae88/0001-disable-ownership-check-for-plugins.patch
-      - type: patch
-        path: patches/NetworkManager/disable-ownership-check-for-plugins.patch
+  - -Dintrospection=true
+  - -Dvapi=false
+  - -Ddocs=false
+  - -Dtests=no
+  - -Dfirewalld_zone=false
+  - -Dlibpsl=false
+  - -Dqt=false
+  cleanup:
+  - /sbin
+  - /etc
+  - /include
+  - /lib/pkgconfig
+  - /libexec
+  - /var
+  - /share/bash-completion
+  - /share/doc
+  sources:
+  - type: git
+    url: https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git
+    tag: 1.56.1
+    commit: b829f838fc5d8c93437faa5db44a5396b67893de # Breaking change in 1.42.x: `dns` will be replaced by `dns-data`, which is incompatible with older NetworkManager on the host system
+  - type: patch
+    path: patches/NetworkManager/disable-ownership-check-for-plugins.patch
 
   # https://github.com/flathub/com.github.jkotra.eovpn/blob/670f19e2aee1c9559fbe4eed904e35500843ae88/com.github.jkotra.eovpn.yml#L133C17-L151
-  - name: libnma
-    buildsystem: meson
-    config-opts:
-      - -Dmobile_broadband_provider_info=false
-      - -Dgtk_doc=false
-      - -Dintrospection=false
-      - -Dvapi=false
-    cleanup:
-      - '*'
-    sources:
-      - type: archive
-        url: https://gitlab.gnome.org/GNOME/libnma/-/archive/1.10.6/libnma-1.10.6.tar.gz
-        sha256: c88fd3408c4ff166b06179b5ce5186e08a57b64eb8c9b22e055ca0dbc5e8002b
-        x-checker-data:
-          type: anitya
-          project-id: 230112
-          stable-only: true
-          url-template: https://gitlab.gnome.org/GNOME/libnma/-/archive/$version/libnma-$version.tar.gz
+- name: libnma
+  buildsystem: meson
+  config-opts:
+  - -Dmobile_broadband_provider_info=false
+  - -Dgtk_doc=false
+  - -Dintrospection=false
+  - -Dvapi=false
+  cleanup:
+  - '*'
+  sources:
+  - type: archive
+    url: https://gitlab.gnome.org/GNOME/libnma/-/archive/1.10.6/libnma-1.10.6.tar.gz
+    sha256: c88fd3408c4ff166b06179b5ce5186e08a57b64eb8c9b22e055ca0dbc5e8002b
 
-  - name: NetworkManager-openvpn
-    buildsystem: autotools
-    sources:
-      - type: git
-        url: https://github.com/NetworkManager/NetworkManager-openvpn.git
-        tag: 1.10.2
-        commit: ae9575dd07cc2d2d51ec8d0297823e07017cb6e6
-        x-checker-data:
-          type: anitya
-          project-id: 69977
-          stable-only: true
-          tag-template: $version
-          versions:
-            # 1.10.4 causes connection failure
-            <: 1.10.4
-
-  # Logs submission when reporting a bug requires journalctl
-  # https://github.com/flathub/org.gnome.Logs/blob/master/org.gnome.Logs.json#L69C9-L146C11
-  - name: systemd
-    buildsystem: meson
-    config-opts:
-      - --libdir=lib
-      - -Dsysconfdir=/app/etc
-      - -Ddocdir=/app/share/doc
-      - -Dsysvinit-path=/app/etc/init.d
-      - -Dfdisk=false
-      - -Ddbus=false
-      - -Dutmp=false
-      - -Dhibernate=false
-      - -Dldconfig=false
-      - -Dresolve=false
-      - -Defi=false
-      - -Dtpm=false
-      - -Denvironment-d=false
-      - -Dbinfmt=false
-      - -Dcoredump=false
-      - -Dlogind=false
-      - -Dhostnamed=false
-      - -Dlocaled=false
-      - -Dmachined=false
-      - -Dportabled=false
-      - -Dnetworkd=false
-      - -Dtimedated=false
-      - -Dtimesyncd=false
-      - -Dremote=false
-      - -Dnss-myhostname=false
-      - -Dnss-mymachines=false
-      - -Dnss-resolve=false
-      - -Dnss-systemd=false
-      - -Dfirstboot=false
-      - -Drandomseed=false
-      - -Dbacklight=false
-      - -Dvconsole=false
-      - -Dquotacheck=false
-      - -Dsysusers=false
-      - -Dtmpfiles=false
-      - -Dimportd=false
-      - -Dhwdb=false
-      - -Drfkill=false
-      - -Dman=false
-      - -Dhtml=false
-      - -Dbashcompletiondir=no
-      - -Dzshcompletiondir=no
-    cleanup:
+- name: NetworkManager-openvpn
+  buildsystem: autotools
+  sources:
+  - type: git
+    url: https://github.com/NetworkManager/NetworkManager-openvpn.git
+    tag: 1.12.5
+    commit: d03d6a636866e9be9fbec7977ef377c191fb2988 # 1.10.4 causes connection failure
+- name: systemd
+  buildsystem: meson
+  config-opts:
+  - --libdir=lib
+  - -Dsysconfdir=/app/etc
+  - -Ddocdir=/app/share/doc
+  - -Dsysvinit-path=/app/etc/init.d
+  - -Dfdisk=false
+  - -Ddbus=false
+  - -Dutmp=false
+  - -Dhibernate=false
+  - -Dldconfig=false
+  - -Dresolve=false
+  - -Defi=false
+  - -Dtpm=false
+  - -Denvironment-d=false
+  - -Dbinfmt=false
+  - -Dcoredump=false
+  - -Dlogind=false
+  - -Dhostnamed=false
+  - -Dlocaled=false
+  - -Dmachined=false
+  - -Dportabled=false
+  - -Dnetworkd=false
+  - -Dtimedated=false
+  - -Dtimesyncd=false
+  - -Dremote=false
+  - -Dnss-myhostname=false
+  - -Dnss-mymachines=false
+  - -Dnss-resolve=false
+  - -Dnss-systemd=false
+  - -Dfirstboot=false
+  - -Drandomseed=false
+  - -Dbacklight=false
+  - -Dvconsole=false
+  - -Dquotacheck=false
+  - -Dsysusers=false
+  - -Dtmpfiles=false
+  - -Dimportd=false
+  - -Dhwdb=false
+  - -Drfkill=false
+  - -Dman=false
+  - -Dhtml=false
+  - -Dbashcompletiondir=no
+  - -Dzshcompletiondir=no
+  cleanup:
       # - /bin
-      - /etc
-      - /lib/libudev*
-      - /lib/kernel
-      - /lib/modprobe.d
-      - /lib/rpm
-      - /lib/sysctl.d
+  - /etc
+  - /lib/libudev*
+  - /lib/kernel
+  - /lib/modprobe.d
+  - /lib/rpm
+  - /lib/sysctl.d
       # - /lib/systemd
-      - /lib/udev
-      - /app/share/doc
-      - /share/dbus-1
-      - /share/doc
-      - /share/factory
-      - /share/glib-2.0
-      - /share/icons
-      - /share/man
-      - /share/pkgconfig
-      - /share/polkit-1
-      - /share/runtime
+  - /lib/udev
+  - /app/share/doc
+  - /share/dbus-1
+  - /share/doc
+  - /share/factory
+  - /share/glib-2.0
+  - /share/icons
+  - /share/man
+  - /share/pkgconfig
+  - /share/polkit-1
+  - /share/runtime
+  sources:
+  - type: git
+    url: https://github.com/systemd/systemd.git
+    tag: v259.5
+    commit: b3d8fc43e9cb531d958c17ef2cd93b374bc14e8a
+  modules:
+  - name: python3-pefile
+    buildsystem: simple
+    build-commands:
+    - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "pefile" --no-build-isolation
     sources:
-      - type: git
-        url: https://github.com/systemd/systemd.git
-        tag: v260.2
-        commit: f1d0952a125b96b7ab2f1ff29a87448ade8ac29b
-        x-checker-data:
-          type: git
-          tag-pattern: ^v([\d.]+)$
-    modules:
-      - name: python3-pefile
-        buildsystem: simple
-        build-commands:
-          - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-            --prefix=${FLATPAK_DEST} "pefile" --no-build-isolation
-        sources:
-          - type: file
-            url: https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz
-            sha256: 3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632
-            x-checker-data:
-              type: pypi
-              name: pefile
+    - type: file
+      url: https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz
+      sha256: 3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632
 
   ######### Cryptography #########
   # https://github.com/flathub/org.gajim.Gajim/blob/cb9cb26dd58acea79c50b316fb66a171b54c18e1/org.gajim.Gajim.yaml#LL66-L131C81
 
-  - name: python3-pycparser
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "pycparser" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
-        sha256: b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
-        x-checker-data:
-          type: pypi
-          name: pycparser
-          packagetype: bdist_wheel
+- name: python3-pycparser
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "pycparser" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl
+    sha256: c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc
 
-  - name: python3-cffi
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "." --no-build-isolation
-    sources:
-      - type: archive
-        url: https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz
-        sha256: 44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529
-        x-checker-data:
-          type: pypi
-          name: cffi
+- name: python3-cffi
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "." --no-build-isolation
+  sources:
+  - type: archive
+    url: https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz
+    sha256: 44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529
 
-  - name: python3-asn1crypto
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "asn1crypto" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/c9/7f/09065fd9e27da0eda08b4d6897f1c13535066174cc023af248fc2a8d5e5a/asn1crypto-1.5.1-py2.py3-none-any.whl
-        sha256: db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67
-        x-checker-data:
-          type: pypi
-          name: asn1crypto
-          packagetype: bdist_wheel
+- name: python3-asn1crypto
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "asn1crypto" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/c9/7f/09065fd9e27da0eda08b4d6897f1c13535066174cc023af248fc2a8d5e5a/asn1crypto-1.5.1-py2.py3-none-any.whl
+    sha256: db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67
 
-  - name: python3-idna
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "idna" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl
-        sha256: 466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c
-        x-checker-data:
-          type: pypi
-          name: idna
-          packagetype: bdist_wheel
+- name: python3-idna
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "idna" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
+    sha256: 771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea
 
-  - name: python3-cryptography
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "cryptography" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl
-        sha256: 40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5
-        only-arches:
-          - aarch64
-        x-checker-data:
-          type: json
-          url: https://pypi.org/pypi/cryptography/json
-          version-query: .info.version
-          url-query: .releases | .[$version][] | select(.filename=="cryptography-"
-            + $version + "-cp311-abi3-manylinux_2_28_aarch64.whl") | .url
-          name: cryptography
-          packagetype: bdist_wheel
+- name: python3-cryptography
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "cryptography" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/60/f8/e61f8f13950ab6195b31913b42d39f0f9afc7d93f76710f299b5ec286ae6/cryptography-46.0.6-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+    sha256: 26031f1e5ca62fcb9d1fcb34b2b60b390d1aacaa15dc8b895a9ed00968b97b30
+    only-arches:
 
-      - type: file
-        url: https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl
-        sha256: a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f
-        only-arches:
-          - x86_64
-        x-checker-data:
-          type: json
-          url: https://pypi.org/pypi/cryptography/json
-          version-query: .info.version
-          url-query: .releases | .[$version][] | select(.filename=="cryptography-"
-            + $version + "-cp311-abi3-manylinux_2_28_x86_64.whl") | .url
-          name: cryptography
-          packagetype: bdist_wheel
+    - aarch64
+  - type: file
+    url: https://files.pythonhosted.org/packages/19/69/732a736d12c2631e140be2348b4ad3d226302df63ef64d30dfdb8db7ad1c/cryptography-46.0.6-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+    sha256: 9a693028b9cbe51b5a1136232ee8f2bc242e4e19d456ded3fa7c86e43c713b4a
+    only-arches:
 
   # The pyopenssl Python library is handled specially since it depends on the above python3-cryptography module.
-  - name: python3-pyopenssl
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "pyopenssl" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl
-        sha256: 4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70
-        x-checker-data:
-          name: pyOpenSSL
-          packagetype: bdist_wheel
-          type: pypi
+    - x86_64
+- name: python3-pyopenssl
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "pyopenssl" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/fb/7d/d4f7d908fa8415571771b30669251d57c3cf313b36a856e6d7548ae01619/pyopenssl-26.0.0-py3-none-any.whl
+    sha256: df94d28498848b98cc1c0ffb8ef1e71e40210d3b0a8064c9d29571ed2904bf81
 
   # https://github.com/flathub/net.lutris.Lutris/blob/7bd51222b8076abd8fcbfe9cb0e4d6e70bafca24/net.lutris.Lutris.yml#L647C1-L740C81
-  - name: python-ninja # needed by dbus-python
+- name: python-ninja   # needed by dbus-python
+  buildsystem: simple
+  build-commands:
+  - python3 setup.py build -j${FLATPAK_BUILDER_N_JOBS} -DARCHIVE_DOWNLOAD_DIR="${FLATPAK_BUILDER_BUILDDIR}"
+  - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" .
+  build-options:
+    env:
+      CMAKE_POLICY_VERSION_MINIMUM: '3.5'
+  cleanup: ['*']
+  sources:
+  - type: archive
+    url: https://files.pythonhosted.org/packages/37/2c/d717d13a413d6f7579cdaa1e28e6e2c98de95461549b08d311c8a5bf4c51/ninja-1.11.1.1.tar.gz
+    sha256: 9d793b08dd857e38d0b6ffe9e6b7145d7c485a42dcfea04905ca0cdb6017cc3c
+
+  - type: file
+    url: https://github.com/Kitware/ninja/archive/refs/tags/v1.11.1.g95dee.kitware.jobserver-1.tar.gz
+    sha256: 7ba84551f5b315b4270dc7c51adef5dff83a2154a3665a6c9744245c122dd0db
+  modules:
+  - pip-resources.python-skbuild.yaml
+  - name: python-skbuild
     buildsystem: simple
     build-commands:
-      - python3 setup.py build -j${FLATPAK_BUILDER_N_JOBS} -DARCHIVE_DOWNLOAD_DIR="${FLATPAK_BUILDER_BUILDDIR}"
-      - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" .
-    build-options:
-      env:
-        CMAKE_POLICY_VERSION_MINIMUM: '3.5'
+    - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" .
     cleanup: ['*']
     sources:
-      - type: archive
-        url: https://files.pythonhosted.org/packages/37/2c/d717d13a413d6f7579cdaa1e28e6e2c98de95461549b08d311c8a5bf4c51/ninja-1.11.1.1.tar.gz
-        sha256: 9d793b08dd857e38d0b6ffe9e6b7145d7c485a42dcfea04905ca0cdb6017cc3c
-
-      - type: file
-        url: https://github.com/Kitware/ninja/archive/refs/tags/v1.11.1.g95dee.kitware.jobserver-1.tar.gz
-        sha256: 7ba84551f5b315b4270dc7c51adef5dff83a2154a3665a6c9744245c122dd0db
+    - type: archive
+      url: https://files.pythonhosted.org/packages/9e/e2/2e440c30e93fc5b505ee56169a4396b05e797a1daadb721aba429adbfd51/scikit-build-0.15.0.tar.gz
+      sha256: e723cd0f3489a042370b9ea988bbb9cfd7725e8b25b20ca1c7981821fcf65fb9
     modules:
-      - pip-resources.python-skbuild.yaml
-      - name: python-skbuild
+    - name: python-setuptools-scm
+      buildsystem: simple
+      build-commands:
+      - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" .
+      cleanup: ['*']
+      sources:
+      - type: archive
+        url: https://files.pythonhosted.org/packages/7b/b1/19587742aad604f1988a8a362e660e8c3ac03adccdb71c96d86526e5eb62/setuptools_scm-9.2.2.tar.gz
+        sha256: 1c674ab4665686a0887d7e24c03ab25f24201c213e82ea689d2f3e169ef7ef57
+      modules:
+      - name: python-vcs-versioning
         buildsystem: simple
         build-commands:
-          - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}"
-            .
+        - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" .
         cleanup: ['*']
         sources:
-          - type: archive
-            url: https://files.pythonhosted.org/packages/9e/e2/2e440c30e93fc5b505ee56169a4396b05e797a1daadb721aba429adbfd51/scikit-build-0.15.0.tar.gz
-            sha256: e723cd0f3489a042370b9ea988bbb9cfd7725e8b25b20ca1c7981821fcf65fb9
-        modules:
-          - name: python-setuptools-scm
-            buildsystem: simple
-            build-commands:
-              - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}"
-                .
-            cleanup: ['*']
-            sources:
-              - type: archive
-                url: https://files.pythonhosted.org/packages/a5/b1/2a6a8ecd6f9e263754036a0b573360bdbd6873b595725e49e11139722041/setuptools_scm-10.0.5.tar.gz
-                sha256: bbba8fe754516cdefd017f4456721775e6ef9662bd7887fb52ae26813d4838c3
-                x-checker-data:
-                  type: pypi
-                  name: setuptools_scm
-            modules:
-              - name: python-vcs-versioning
-                buildsystem: simple
-                build-commands:
-                  - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}"
-                    .
-                cleanup: ['*']
-                sources:
-                  - type: archive
-                    url: https://files.pythonhosted.org/packages/49/42/d97a7795055677961c63a1eef8e7b19d5968ed992ed3a70ab8eb012efad8/vcs_versioning-1.1.1.tar.gz
-                    sha256: fabd75a3cab7dd8ac02fe24a3a9ba936bf258667b5a62ed468c9a1da0f5775bc
-                    x-checker-data:
-                      type: pypi
-                      name: vcs-versioning
-              - name: python-tomli
-                buildsystem: simple
-                build-commands:
-                  - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}"
-                    .
-                cleanup: ['*']
-                sources:
-                  - type: archive
-                    url: https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz
-                    sha256: 7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f
-                    x-checker-data:
-                      type: pypi
-                      name: tomli
-          - name: python-distro # also needed by Lutris, do not add a cleanup property here!
-            buildsystem: simple
-            build-commands:
-              - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}"
-                .
-            sources:
-              - type: archive
-                url: https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz
-                sha256: 2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed
-                x-checker-data:
-                  type: pypi
-                  name: distro
-
-  - name: python-meson # needed by dbus-python, the meson version shipped by the SDK is too old (0.59<0.60)
-    buildsystem: simple
-    build-commands:
-      - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" --ignore-installed
-        .
-    cleanup: ['*']
-    sources:
+        - type: archive
+          url: https://files.pythonhosted.org/packages/49/42/d97a7795055677961c63a1eef8e7b19d5968ed992ed3a70ab8eb012efad8/vcs_versioning-1.1.1.tar.gz
+          sha256: fabd75a3cab7dd8ac02fe24a3a9ba936bf258667b5a62ed468c9a1da0f5775bc
+          x-checker-data:
+            type: pypi
+            name: vcs-versioning
+      - name: python-tomli
+        buildsystem: simple
+        build-commands:
+        - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" .
+        cleanup: ['*']
+        sources:
+        - type: archive
+          url: https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz
+          sha256: 7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f
+    - name: python-distro       # also needed by Lutris, do not add a cleanup property here!
+      buildsystem: simple
+      build-commands:
+      - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" .
+      sources:
       - type: archive
-        url: https://files.pythonhosted.org/packages/ce/99/f2e4780865ebabda14ab03b98def0bf27c021efaf7ec7138c1dbbf1c72cb/meson-1.10.2.tar.gz
-        sha256: 7890287d911dd4ee1ebd0efb61ed0321bfcd87c725df923a837cf90c6508f96b
-        x-checker-data:
-          type: pypi
-          name: meson
+        url: https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz
+        sha256: 2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed
+
+- name: python-meson   # needed by dbus-python, the meson version shipped by the SDK is too old (0.59<0.60)
+  buildsystem: simple
+  build-commands:
+  - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" --ignore-installed .
+  cleanup: ['*']
+  sources:
+  - type: archive
+    url: https://files.pythonhosted.org/packages/ce/99/f2e4780865ebabda14ab03b98def0bf27c021efaf7ec7138c1dbbf1c72cb/meson-1.10.2.tar.gz
+    sha256: 7890287d911dd4ee1ebd0efb61ed0321bfcd87c725df923a837cf90c6508f96b
 
   # https://github.com/flathub/net.lutris.Lutris/blob/7bd51222b8076abd8fcbfe9cb0e4d6e70bafca24/net.lutris.Lutris.yml#L772-L786
-  - name: python-dbus
-    buildsystem: simple
-    build-commands:
+- name: python-dbus
+  buildsystem: simple
+  build-commands:
       # Setting `PYTHONPATH` and using the deprecated `./setup.py install`
       # in the following line are workarounds to force usage of the newer
       # meson version installed above
       #
       # The next FreeDesktop SDK update should make this (and installing
       # our own version of meson) unnecessary.
-      - PYTHONPATH=/app/lib/python3.11/site-packages python3 ./setup.py install --prefix="${FLATPAK_DEST}"
-        --root=/
-    sources:
-      - type: archive
-        url: https://dbus.freedesktop.org/releases/dbus-python/dbus-python-1.3.2.tar.gz
-        sha256: ad67819308618b5069537be237f8e68ca1c7fcc95ee4a121fe6845b1418248f8
-        x-checker-data:
-          type: anitya
-          project-id: 402
-          url-template: https://dbus.freedesktop.org/releases/dbus-python/dbus-python-$version.tar.gz
+  - PYTHONPATH=/app/lib/python3.11/site-packages python3 ./setup.py install --prefix="${FLATPAK_DEST}" --root=/
+  sources:
+  - type: archive
+    url: https://dbus.freedesktop.org/releases/dbus-python/dbus-python-1.4.0.tar.xz
+    sha256: c36b28f10ffcc8f1f798aca973bcc132f91f33eb9b6b8904381b4077766043d5
 
   # For network status detection: https://github.com/ProtonVPN/proton-vpn-gtk-app/blob/a6a3ea0b2a0c17ebbba4eb9f80c8b164092050b9/proton/vpn/app/gtk/services/reconnector/network_monitor.py#L41
-  - name: iproute2
-    buildsystem: autotools
-    make-install-args:
-      - PREFIX=${FLATPAK_DEST}
-      - SBINDIR=${FLATPAK_DEST}/bin
-      - CONFDIR=${FLATPAK_DEST}/etc/iproute2
-    sources:
-      - type: archive
-        url: https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-7.0.0.tar.xz
-        sha256: e62890f7b5de63c05a3bf331dc8deb4c015c336013f341a4edf46969797f2f4e
-        x-checker-data:
-          project-id: 1392
-          stable-only: true
-          type: anitya
-          url-template: https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-$version.tar.xz
+- name: iproute2
+  buildsystem: autotools
+  make-install-args:
+  - PREFIX=${FLATPAK_DEST}
+  - SBINDIR=${FLATPAK_DEST}/bin
+  - CONFDIR=${FLATPAK_DEST}/etc/iproute2
+  sources:
+  - type: archive
+    url: https://github.com/iproute2/iproute2/archive/refs/tags/v6.17.0.tar.gz
+    sha256: fcf83a51254fc3de6afe7a110c7a91e10e723898283ff232f319bbc90c9f0666
 
   ######### Proton Services #########
 
-  - name: python-proton-core
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "." --no-build-isolation
-    modules:
+- name: python-proton-core
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "." --no-build-isolation
+  modules:
       # flatpak-pip-generator --checker-data --yaml --runtime='org.gnome.Sdk//49' "expandvars" "requests" "python-gnupg" "aiohttp" "pyxdg" -o pip-resources.python-proton-core
       # `expandvars` is required by `yarl`
       # https://github.com/ProtonVPN/python-proton-core/blob/8ab41013fcedd8fe16dffe0992f60cbdbd01fe0b/setup.py#L12C23-L12C129
-      - pip-resources.python-proton-core.yaml
-    sources:
-      - type: git
-        url: https://github.com/ProtonVPN/python-proton-core
-        tag: v0.7.0
-        commit: f7a178a99c3adc0e88c7f91d4db5371a052c4985
-        x-checker-data:
-          type: anitya
-          project-id: 369954
-          tag-template: v$version
+  - pip-resources.python-proton-core.yaml
+  sources:
+  - type: git
+    url: https://github.com/ProtonVPN/python-proton-core
+    tag: v0.7.0
+    commit: f7a178a99c3adc0e88c7f91d4db5371a052c4985
+    x-checker-data:
+      type: anitya
+      project-id: 369954
+      tag-template: v$version
 
-  - name: python-proton-keyring-linux
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "." --no-build-isolation
-    modules:
+- name: python-proton-keyring-linux
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "." --no-build-isolation
+  modules:
       # flatpak-pip-generator --checker-data --yaml --runtime='org.gnome.Sdk//49' "keyring" -o pip-resources.python-proton-keyring-linux
       # https://github.com/ProtonVPN/python-proton-keyring-linux/blob/5ff3c7f9a1a162836649502dd23c2fbe1f487d73/setup.py#L12C39-L12C46
       # Remove the cryptography module as it has been included above
-      - pip-resources.python-proton-keyring-linux.yaml
-    sources:
-      - type: git
-        url: https://github.com/ProtonVPN/python-proton-keyring-linux
-        tag: v0.2.1
-        commit: 1534c2f09d73ad18a073c09dd314e11c9da895e0
-        x-checker-data:
-          type: anitya
-          project-id: 369953
-          tag-template: v$version
+  - pip-resources.python-proton-keyring-linux.yaml
+  sources:
+  - type: git
+    url: https://github.com/ProtonVPN/python-proton-keyring-linux
+    tag: v0.2.1
+    commit: 1534c2f09d73ad18a073c09dd314e11c9da895e0
+    x-checker-data:
+      type: anitya
+      project-id: 369953
+      tag-template: v$version
 
-  - name: python-proton-vpn-api-core
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "." --no-build-isolation
-    modules:
+- name: python-proton-vpn-api-core
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "." --no-build-isolation
+  modules:
       # Add "proton-vpn-local-agent" here as well so that the python distribution metadata is included
       # flatpak-pip-generator --checker-data --yaml --runtime='org.gnome.Sdk//49' "fido2" "distro" "sentry-sdk" "PyNaCl" "proton-vpn-local-agent" -o pip-resources.python-proton-vpn-api-core
       # https://github.com/ProtonVPN/python-proton-vpn-api-core/blob/e26e3fa70077d24a53465c87ebdd6026e3c7c080/setup.py#L17-L18C46
-      - pip-resources.python-proton-vpn-api-core.yaml
-    sources:
-      - type: git
-        url: https://github.com/ProtonVPN/python-proton-vpn-api-core
-        tag: v5.2.4
-        commit: c31b15947adcc71210453a4ded7f3cbcdfa19e5f
-        disable-submodules: true
-        x-checker-data:
-          type: anitya
-          project-id: 369944
-          tag-template: v$version
-      - type: patch
-        path: patches/python-proton-vpn-api-core/fix-ip-path.patch
+  - pip-resources.python-proton-vpn-api-core.yaml
+  sources:
+  - type: git
+    url: https://github.com/ProtonVPN/python-proton-vpn-api-core
+    tag: v5.2.4
+    commit: c31b15947adcc71210453a4ded7f3cbcdfa19e5f
+    disable-submodules: true
+    x-checker-data:
+      type: anitya
+      project-id: 369944
+      tag-template: v$version
+  - type: patch
+    path: patches/python-proton-vpn-api-core/fix-ip-path.patch
 
-  - name: python-proton-vpn-local-agent
-    buildsystem: simple
-    build-commands:
-      - bsdtar -Oxf python-proton-vpn-local-agent.deb data.tar.xz | bsdtar -xf -
-      - |
-        PYTHON_VERSION=$(python3 -c 'import sys; print("{}.{}".format(*sys.version_info))');
-        install -Dm755 usr/lib/python3/dist-packages/proton/vpn/local_agent.abi3.so "${FLATPAK_DEST}/lib/python${PYTHON_VERSION}/site-packages/proton/vpn/local_agent.abi3.so"
-    sources:
-      - type: file
-        only-arches: [x86_64]
-        dest-filename: python-proton-vpn-local-agent.deb
-        url: https://repo.protonvpn.com/debian/dists/stable/main/binary-amd64/python3-proton-vpn-local-agent_1.6.3_amd64.deb
-        sha256: dab3a51bf8fe97116a284ba2f143ac5a904a0305ace8e319c051800244129bb5
-        x-checker-data:
-          type: debian-repo
-          package-name: python3-proton-vpn-local-agent
-          root: https://repo.protonvpn.com/debian
-          dist: stable
-          component: main
-      - type: file
-        only-arches: [aarch64]
-        dest-filename: python-proton-vpn-local-agent.deb
-        url: https://repo.protonvpn.com/debian/dists/stable/main/binary-arm64/python3-proton-vpn-local-agent_1.6.3_arm64.deb
-        sha256: 9d682c6bc302b848d92ea45d876a5a5445e89a673986b489430bc28471822b69
-        x-checker-data:
-          type: debian-repo
-          package-name: python3-proton-vpn-local-agent
-          root: https://repo.protonvpn.com/debian
-          dist: stable
-          component: main
+- name: python-proton-vpn-local-agent
+  buildsystem: simple
+  build-commands:
+  - bsdtar -Oxf python-proton-vpn-local-agent.deb data.tar.xz | bsdtar -xf -
+  - |
+    PYTHON_VERSION=$(python3 -c 'import sys; print("{}.{}".format(*sys.version_info))');
+    install -Dm755 usr/lib/python3/dist-packages/proton/vpn/local_agent.abi3.so "${FLATPAK_DEST}/lib/python${PYTHON_VERSION}/site-packages/proton/vpn/local_agent.abi3.so"
+  sources:
+  - type: file
+    only-arches: [x86_64]
+    dest-filename: python-proton-vpn-local-agent.deb
+    url: https://repo.protonvpn.com/debian/dists/stable/main/binary-amd64/python3-proton-vpn-local-agent_1.6.3_amd64.deb
+    sha256: dab3a51bf8fe97116a284ba2f143ac5a904a0305ace8e319c051800244129bb5
+    x-checker-data:
+      type: debian-repo
+      package-name: python3-proton-vpn-local-agent
+      root: https://repo.protonvpn.com/debian
+      dist: stable
+      component: main
+  - type: file
+    only-arches: [aarch64]
+    dest-filename: python-proton-vpn-local-agent.deb
+    url: https://repo.protonvpn.com/debian/dists/stable/main/binary-arm64/python3-proton-vpn-local-agent_1.6.3_arm64.deb
+    sha256: 9d682c6bc302b848d92ea45d876a5a5445e89a673986b489430bc28471822b69
+    x-checker-data:
+      type: debian-repo
+      package-name: python3-proton-vpn-local-agent
+      root: https://repo.protonvpn.com/debian
+      dist: stable
+      component: main
 
-  - name: proton-vpn-cli
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "." --no-build-isolation
-    modules:
+- name: proton-vpn-cli
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "." --no-build-isolation
+  modules:
       # flatpak-pip-generator --checker-data --yaml --runtime='org.gnome.Sdk//49' "click" "dbus-fast" "tabulate" -o pip-resources.proton-vpn-cli
       # https://github.com/ProtonVPN/proton-vpn-cli/blob/f00eb2a07e810f9563323bd38ee4a7bd3c3226c8/setup.py#L16-L23
-      - pip-resources.proton-vpn-cli.yaml
-    sources:
-      - type: git
-        url: https://github.com/ProtonVPN/proton-vpn-cli.git
-        tag: v1.0.0
-        commit: f00eb2a07e810f9563323bd38ee4a7bd3c3226c8
-        disable-submodules: true
+  - pip-resources.proton-vpn-cli.yaml
+  sources:
+  - type: git
+    url: https://github.com/ProtonVPN/proton-vpn-cli.git
+    tag: v1.0.0
+    commit: f00eb2a07e810f9563323bd38ee4a7bd3c3226c8
+    disable-submodules: true
 
-  - name: proton-vpn-gtk-app
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "." --no-build-isolation
+- name: proton-vpn-gtk-app
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "." --no-build-isolation
 
-      - install -Dm644 rpmbuild/SOURCES/proton.vpn.app.gtk.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
-      - desktop-file-edit --set-icon ${FLATPAK_ID} --set-key Exec --set-value 'protonvpn-app
-        %u' ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
+  - install -Dm644 rpmbuild/SOURCES/proton.vpn.app.gtk.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
+  - desktop-file-edit --set-icon ${FLATPAK_ID} --set-key Exec --set-value 'protonvpn-app %u' ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
 
-      - install -Dm644 rpmbuild/SOURCES/proton-vpn-logo.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
+  - install -Dm644 rpmbuild/SOURCES/proton-vpn-logo.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
       # Export icons that can be used in the status bar: https://github.com/flathub/com.protonvpn.www/issues/100
       # Icons to be exported must have names following the pattern: ${FLATPAK_ID}.icon_name.svg
-      - |
-        PYTHON_VERSION=$(python3 -c 'import sys; print("{}.{}".format(*sys.version_info))')
-        PYTHONPATH=${FLATPAK_DEST}/lib/python${PYTHON_VERSION}/site-packages
-        for icon in maintenance-icon proton-vpn-sign state-connected state-disconnected state-error
-        do
-          mv ${PYTHONPATH}/proton/vpn/app/gtk/assets/icons/${icon}.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.${icon}.svg
-          ln -s ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.${icon}.svg ${PYTHONPATH}/proton/vpn/app/gtk/assets/icons/${icon}.svg
-        done
-      - install -Dm644 com.protonvpn.www.metainfo.xml "${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml"
-    modules:
+  - |
+    PYTHON_VERSION=$(python3 -c 'import sys; print("{}.{}".format(*sys.version_info))')
+    PYTHONPATH=${FLATPAK_DEST}/lib/python${PYTHON_VERSION}/site-packages
+    for icon in maintenance-icon proton-vpn-sign state-connected state-disconnected state-error
+    do
+      mv ${PYTHONPATH}/proton/vpn/app/gtk/assets/icons/${icon}.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.${icon}.svg
+      ln -s ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.${icon}.svg ${PYTHONPATH}/proton/vpn/app/gtk/assets/icons/${icon}.svg
+    done
+  - install -Dm644 com.protonvpn.www.metainfo.xml "${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml"
+  modules:
       # flatpak-pip-generator --checker-data --yaml --runtime='org.gnome.Sdk//49' "pygobject" "pycairo" -o pip-resources.proton-vpn-gtk-app
       # https://github.com/ProtonVPN/proton-vpn-gtk-app/blob/9bb65236353d646b07ead7b417d3828b12b55b7c/setup.py#L12-L19
-      - pip-resources.proton-vpn-gtk-app.yaml
-    sources:
-      - type: git
-        url: https://github.com/ProtonVPN/proton-vpn-gtk-app
-        tag: v4.16.5
-        commit: d266ac6924caec49a51175e598649f53b1a1bdfa
-        disable-submodules: true
-        x-checker-data:
-          type: anitya
-          project-id: 369943
-          tag-template: v$version
-          is-main-source: true
+  - pip-resources.proton-vpn-gtk-app.yaml
+  sources:
+  - type: git
+    url: https://github.com/ProtonVPN/proton-vpn-gtk-app
+    tag: v4.16.5
+    commit: d266ac6924caec49a51175e598649f53b1a1bdfa
+    disable-submodules: true
+    x-checker-data:
+      type: anitya
+      project-id: 369943
+      tag-template: v$version
+      is-main-source: true
 
-      - type: patch
-        path: patches/proton-vpn-gtk-app/fix-tray-icons.patch
+  - type: patch
+    path: patches/proton-vpn-gtk-app/fix-tray-icons.patch
 
-      - type: file
-        path: com.protonvpn.www.metainfo.xml
+  - type: file
+    path: com.protonvpn.www.metainfo.xml

--- a/com.protonvpn.www.yml
+++ b/com.protonvpn.www.yml
@@ -148,7 +148,7 @@ modules:
     url: https://files.pythonhosted.org/packages/bb/5d/6d7433e0f3cd46ce0b43cd65e1db465ea024dbb8216fb2404e919c2ad77b/bcrypt-4.3.0.tar.gz
     sha256: 3a3fd2204178b6d2adcf09cb4f6426ffef54762577a7c9b54c159008cb288c18
       # The Cargo sources should be updated whenever bcrypt is updated.
-      # wget https://raw.githubusercontent.com/pyca/bcrypt/refs/tags/5.0.0/src/_bcrypt/Cargo.lock -O /tmp/Cargo.lock
+      # wget https://raw.githubusercontent.com/pyca/bcrypt/refs/tags/4.3.0/src/_bcrypt/Cargo.lock -O /tmp/Cargo.lock
       # python flatpak-builder-tools/cargo/flatpak-cargo-generator.py -o bcrypt-cargo-sources.json /tmp/Cargo.lock
   - bcrypt-cargo-sources.json
 

--- a/com.protonvpn.www.yml
+++ b/com.protonvpn.www.yml
@@ -219,6 +219,7 @@ modules:
   - -Dfirewalld_zone=false
   - -Dlibpsl=false
   - -Dqt=false
+  - -Dnm_cloud_setup=false
   cleanup:
   - /sbin
   - /etc

--- a/com.protonvpn.www.yml
+++ b/com.protonvpn.www.yml
@@ -220,6 +220,13 @@ modules:
   - -Dlibpsl=false
   - -Dqt=false
   - -Dnm_cloud_setup=false
+  - -Dnbft=false
+  - -Dsession_tracking_consolekit=false
+  - -Dpolkit=false
+  - -Dconcheck=false
+  - -Debpf=false
+  - -Dman=false
+  - -Dreadline=none
   cleanup:
   - /sbin
   - /etc

--- a/docs/superpowers/plans/2026-07-01-fedora-stable-flatpak-deps-plan.md
+++ b/docs/superpowers/plans/2026-07-01-fedora-stable-flatpak-deps-plan.md
@@ -1,0 +1,2540 @@
+# Fedora-Stable Flatpak Dependency Pinning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `scripts/fedora_flatpak_updater/`, a scheduled tool that resolves every third-party dependency in `com.protonvpn.www.yml` (and its five `pip-resources.*.yaml` files) to the version Fedora's latest stable release ships, patches the manifests in place, and opens a PR — replacing the incomplete `fedora_pip_updater` scratch work.
+
+**Architecture:** A small Python package with one client per external service (Bodhi, MDAPI, PyPI JSON, `git ls-remote`), one "recipe" module per source kind (`pypi`, `pypi-multi-wheel`, `archive`, `git`), a `ruamel.yaml`-based patcher that mutates the manifest forest in place, and a CLI that orchestrates a full run. A `.fedora-tracked-modules.yaml` mapping file at the repo root is the single source of truth for which modules are tracked and how to resolve their sources.
+
+**Tech Stack:** Python 3.10+, managed with `uv`. `requests`, `ruamel.yaml` (round-trip mode), `tenacity`, `click`, `tabulate`, `packaging`. Dev-only: `pytest`, `responses`. CI: GitHub Actions, `astral-sh/setup-uv`, `peter-evans/create-pull-request`.
+
+## Global Constraints
+
+- Proton-owned modules (`python-proton-core`, `python-proton-keyring-linux`, `python-proton-vpn-api-core`, `python-proton-vpn-local-agent`, `proton-vpn-cli`, `proton-vpn-gtk-app`, and the `proton-vpn-local-agent` PyPI wheel) are never touched. General rule: any package whose PyPI/Fedora name starts with `proton` (case-insensitive) is excluded.
+- `NetworkManager` and `NetworkManager-openvpn` version ceilings (`versions: < 1.42.0` / `< 1.10.4`) are dropped — always take whatever version Fedora ships.
+- All HTTP and `git` calls are mocked in unit tests. No real network access in the test suite.
+- `x-checker-data` is removed from every source block the tool successfully patches (so Flathub's `flatpak-external-data-checker` stops fighting the pinned version). Untouched (skipped/Proton) blocks keep whatever `x-checker-data` they already had.
+- Fedora branch resolution (`f44`, `f45`, ...) is always automatic via Bodhi. No manual "bump the target Fedora version" step ever exists.
+- The package is installed and run exclusively through `uv` (`uv sync`, `uv run`) — no bare `pip`/`venv` commands.
+
+## Third-Party Libraries Adopted
+
+Beyond the two load-bearing libraries the design doc already calls for (`requests` for HTTP, `ruamel.yaml` for comment/anchor-preserving round-trip YAML, for which there is no simpler popular alternative), this plan adopts:
+
+- **`tenacity`** — replaces hand-rolled retry loops. `fedora_release.py` retries once on any `requests.RequestException`; `mdapi_client.py` retries once on a 5xx status. Both become a `@retry(...)` decorator instead of a manual `for attempt in range(...)` loop.
+- **`click`** — replaces `argparse` in `cli.py` and `migrate.py`. Less boilerplate, auto-generated `--help`, and it's already a real dependency this tool tracks (`pip-resources.proton-vpn-cli.yaml`).
+- **`tabulate`** — replaces a hand-built markdown table string in `cli.format_summary()`. `tabulate(rows, headers=[...], tablefmt="github")` produces the exact GitHub-flavored markdown table the PR body needs. Also already tracked by this tool.
+- **`packaging`** — replaces hand-rolled PEP 503 normalization regexes in `manifest_patcher.py` and `migrate.py` with `packaging.utils.canonicalize_name()`, the reference implementation pip itself uses.
+- **`responses`** (dev-only) — replaces hand-rolled `FakeResponse`/`FakeSession` test doubles entirely. `@responses.activate` + `responses.add(responses.GET, url, json=..., status=...)` mocks `requests` at the transport layer, so tests are declarative and don't need session-injection plumbing to be testable.
+
+**Considered and not adopted:**
+- **`pydantic`** — would replace `mapping_loader.py`'s ~15 lines of manual key-checking with schema validation. Skipped: the mapping file's shape is small and stable enough that the manual version is easy to read; revisit if the schema grows.
+- **`GitPython`** — would wrap `git ls-remote --tags`. Skipped: a single subprocess call is simpler and lighter than a full git-porcelain dependency, and the injectable `runner` callable already makes it trivially mockable.
+- **`httpx`** — no benefit over `requests` here (no async need), and `responses` mocks `requests` more seamlessly than `httpx`'s mocking story for this project's needs.
+
+## Design Clarification (read before starting)
+
+The design doc's `.fedora-tracked-modules.yaml` example keys entries by "the exact Flatpak module `name`" and says the patcher "finds every source block belonging to a given module name." Inspecting the real manifest tree shows this needs one refinement for `pypi`/`pypi-multi-wheel` recipes:
+
+Flatpak modules generated by `flatpak-pip-generator` routinely **bundle several unrelated PyPI packages as sibling `sources` entries under one module name** (e.g. the module `python3-requests` in `pip-resources.python-proton-core.yaml` bundles `certifi`, `charset_normalizer`, `idna`, `requests`, and `urllib3` as five separate source blocks; the module `python3-setuptools_scm` in `com.protonvpn.www.yml` bundles `vcs-versioning`, `pyparsing`, `tomli`, and `setuptools_scm`). The same PyPI package (e.g. `idna`, `cffi`, `cryptography`) also appears as a source block nested inside several *different* carrier modules across different files, never as a standalone module with a matching `name:` field.
+
+Because of this, **Task 9 matches `pypi`/`pypi-multi-wheel` sources by the resolved PyPI distribution name found in the source's `url` filename prefix (normalized via `packaging.utils.canonicalize_name`), not by any module's `name:` field.** This is also what makes it safe to strip `x-checker-data` on every patched run: relocation on the *next* run no longer depends on `x-checker-data.name` surviving. Native `archive`/`git` recipes (`libndp`, `polkit`, `libnma`, `NetworkManager`, `NetworkManager-openvpn`, `systemd`, `iproute2`, `python-dbus`) *are* real standalone modules, so those are matched by the module's `name:` field, exactly as the design doc describes.
+
+If this refinement is wrong for your intent, stop and raise it before Task 9 — it is the load-bearing decision for the whole patcher.
+
+## File Structure
+
+```
+scripts/fedora_flatpak_updater/
+  pyproject.toml
+  uv.lock                 # generated by `uv sync`, committed
+  README.md
+  src/fedora_flatpak_updater/
+    __init__.py
+    fedora_release.py      # Bodhi client -> current stable branch string (tenacity retry)
+    mdapi_client.py        # MdapiClient -> per-package Fedora version, cache + 404/5xx handling (tenacity retry)
+    models.py              # RecipeKind enum, ModuleSpec dataclass
+    mapping_loader.py      # .fedora-tracked-modules.yaml -> list[ModuleSpec]
+    manifest_patcher.py    # ruamel.yaml forest loader + matchers + patch functions (packaging.canonicalize_name)
+    migrate.py             # one-off helper that drafts the initial mapping file (click CLI)
+    cli.py                 # orchestration + click entry point (tabulate summary table)
+    recipes/
+      __init__.py
+      pypi.py               # resolve/resolve_wheel/resolve_sdist/resolve_multi_wheel
+      archive.py            # render_url + sha256 download
+      git.py                # ls-remote + peeled-tag resolution
+
+tests/fedora_flatpak_updater/
+  __init__.py
+  test_fedora_release.py     # responses
+  test_mdapi_client.py       # responses
+  test_mapping_loader.py
+  test_recipes_pypi.py       # responses
+  test_recipes_archive.py    # responses
+  test_recipes_git.py        # injectable runner callable, no HTTP
+  test_manifest_patcher.py
+  test_cli.py                # click.testing.CliRunner + direct run()/format_summary() calls
+  fixtures/
+    root.yml
+    pip-resources.example.yaml
+
+.fedora-tracked-modules.yaml            # repo root, the mapping data
+.github/workflows/update-fedora-flatpak-deps.yml       # scheduled run + PR
+.github/workflows/test-fedora-flatpak-updater.yml      # conditional test run on changes to the updater itself
+```
+
+Deleted as part of Task 1: `scripts/fedora_pip_updater/`, `.fedora-pip-mapping.yaml`, `tests/fedora_pip_updater/`, `docs/superpowers/plans/2026-05-29-fedora-pip-versions-workflow.md`.
+
+All commands in this plan are run **from the repository root**, using `uv run --project scripts/fedora_flatpak_updater <command>` (which uses that project's environment without changing the working directory, so relative paths like `tests/fedora_flatpak_updater/...` and `com.protonvpn.www.yml` resolve against the repo root as expected).
+
+---
+
+### Task 1: Delete the obsolete scratch work
+
+**Files:**
+- Delete: `scripts/fedora_pip_updater/` (whole directory)
+- Delete: `.fedora-pip-mapping.yaml`
+- Delete: `tests/fedora_pip_updater/` (whole directory)
+- Delete: `docs/superpowers/plans/2026-05-29-fedora-pip-versions-workflow.md`
+
+**Interfaces:** None — this task has no code dependencies on later tasks.
+
+- [ ] **Step 1: Delete the four paths**
+
+```bash
+git rm -r --cached scripts/fedora_pip_updater tests/fedora_pip_updater .fedora-pip-mapping.yaml docs/superpowers/plans/2026-05-29-fedora-pip-versions-workflow.md 2>/dev/null
+rm -rf scripts/fedora_pip_updater tests/fedora_pip_updater
+rm -f .fedora-pip-mapping.yaml docs/superpowers/plans/2026-05-29-fedora-pip-versions-workflow.md
+```
+
+- [ ] **Step 2: Verify nothing references the deleted package**
+
+```bash
+grep -rn "fedora_pip_updater\|fedora-pip-mapping" --include="*.py" --include="*.yml" --include="*.yaml" --include="*.md" .
+```
+
+Expected: no output (empty).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "chore: remove incomplete fedora_pip_updater scratch work"
+```
+
+---
+
+### Task 2: Scaffold the new package with `uv`
+
+**Files:**
+- Create: `scripts/fedora_flatpak_updater/pyproject.toml`
+- Create: `scripts/fedora_flatpak_updater/README.md`
+- Create: `scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/__init__.py`
+- Create: `scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/__init__.py`
+- Create: `tests/fedora_flatpak_updater/__init__.py`
+- Modify: `.gitignore`
+
+**Interfaces:** None — pure scaffolding, consumed implicitly by every later task's `uv run` commands.
+
+- [ ] **Step 1: Create the package's `pyproject.toml`**
+
+```toml
+[project]
+name = "fedora-flatpak-updater"
+version = "0.1.0"
+description = "Pins third-party Flatpak manifest dependencies to Fedora-stable versions"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "requests>=2.32",
+    "ruamel.yaml>=0.18",
+    "tenacity>=9.0",
+    "click>=8.1",
+    "tabulate>=0.9",
+    "packaging>=24.0",
+]
+
+[project.scripts]
+fedora-flatpak-updater = "fedora_flatpak_updater.cli:main"
+fedora-flatpak-updater-migrate = "fedora_flatpak_updater.migrate:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "responses>=0.25",
+]
+```
+
+- [ ] **Step 2: Create `scripts/fedora_flatpak_updater/README.md`**
+
+```markdown
+# fedora_flatpak_updater
+
+Pins every third-party dependency in `com.protonvpn.www.yml` and its
+`pip-resources.*.yaml` files to the version shipped in Fedora's latest
+stable release. See `docs/superpowers/specs/2026-07-01-fedora-stable-flatpak-deps-design.md`
+for the full design.
+
+## Setup
+
+From the repository root:
+
+    uv sync --project scripts/fedora_flatpak_updater
+
+This creates `scripts/fedora_flatpak_updater/.venv` and installs runtime +
+dev dependencies from `uv.lock`.
+
+## Usage
+
+    uv run --project scripts/fedora_flatpak_updater python -m fedora_flatpak_updater.cli --dry-run
+    uv run --project scripts/fedora_flatpak_updater python -m fedora_flatpak_updater.cli --only python3-idna --only libndp
+
+## Rebuilding the mapping file from scratch
+
+    uv run --project scripts/fedora_flatpak_updater python -m fedora_flatpak_updater.migrate > /tmp/draft.yaml
+
+Review the draft, hand-fix anything flagged `_needs_manual_fix`, and merge
+it into `.fedora-tracked-modules.yaml`.
+
+## Running tests
+
+    uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater -v
+```
+
+- [ ] **Step 3: Create empty package `__init__.py` files**
+
+```python
+# scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/__init__.py
+```
+
+```python
+# scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/__init__.py
+```
+
+```python
+# tests/fedora_flatpak_updater/__init__.py
+```
+
+- [ ] **Step 4: Add the venv directory to `.gitignore` (keep `uv.lock` tracked)**
+
+```
+### Python (fedora_flatpak_updater) ###
+scripts/fedora_flatpak_updater/.venv
+**/__pycache__/
+.pytest_cache
+```
+
+Append this block to the end of the existing `.gitignore`.
+
+- [ ] **Step 5: Sync the environment with `uv`**
+
+```bash
+uv sync --project scripts/fedora_flatpak_updater
+```
+
+Expected: `uv` creates `scripts/fedora_flatpak_updater/.venv` and `scripts/fedora_flatpak_updater/uv.lock`, installing `requests`, `ruamel.yaml`, `tenacity`, `click`, `tabulate`, `packaging`, `pytest`, `responses`.
+
+- [ ] **Step 6: Run pytest to confirm the empty suite collects cleanly**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater -v
+```
+
+Expected: `no tests ran` (0 collected, exit code 0), no import errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "chore: scaffold fedora_flatpak_updater package (uv-managed)"
+```
+
+---
+
+### Task 3: `fedora_release.py` (Bodhi client, via `tenacity`)
+
+**Files:**
+- Create: `scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/fedora_release.py`
+- Test: `tests/fedora_flatpak_updater/test_fedora_release.py`
+
+**Interfaces:**
+- Consumes: `tenacity.retry`, `tenacity.retry_if_exception_type`, `tenacity.stop_after_attempt`
+- Produces: `get_current_stable_branch(session=None) -> str`, `BodhiLookupError`. Consumed later by `mdapi_client.py` usage in `cli.py` (`cli.py` imports `get_current_stable_branch` and `BodhiLookupError` directly from `fedora_flatpak_updater.fedora_release`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/fedora_flatpak_updater/test_fedora_release.py
+from __future__ import annotations
+
+import pytest
+import requests
+import responses
+
+from fedora_flatpak_updater.fedora_release import BodhiLookupError, get_current_stable_branch
+
+BODHI_URL = "https://bodhi.fedoraproject.org/releases/"
+
+SAMPLE_PAYLOAD = {
+    "releases": [
+        {"id_prefix": "FEDORA", "version": "43", "released_on": "2025-04-15", "state": "current"},
+        {"id_prefix": "FEDORA", "version": "44", "released_on": "2025-11-11", "state": "current"},
+        {"id_prefix": "FEDORA", "version": "45", "released_on": None, "state": "current"},
+        {"id_prefix": "FEDORA-CONTAINER", "version": "44", "released_on": "2025-11-11", "state": "current"},
+        {"id_prefix": "FEDORA-FLATPAK", "version": "44", "released_on": "2025-11-11", "state": "current"},
+        {"id_prefix": "FEDORA-EPEL", "version": "9", "released_on": "2022-01-01", "state": "current"},
+    ]
+}
+
+
+@responses.activate
+def test_picks_highest_released_fedora_version():
+    responses.add(responses.GET, BODHI_URL, json=SAMPLE_PAYLOAD, status=200)
+    assert get_current_stable_branch() == "f44"
+
+
+@responses.activate
+def test_retries_once_on_transient_failure_then_succeeds():
+    responses.add(responses.GET, BODHI_URL, body=requests.exceptions.ConnectionError("network blip"))
+    responses.add(responses.GET, BODHI_URL, json=SAMPLE_PAYLOAD, status=200)
+    assert get_current_stable_branch() == "f44"
+
+
+@responses.activate
+def test_raises_bodhi_lookup_error_after_exhausting_retries():
+    responses.add(responses.GET, BODHI_URL, body=requests.exceptions.ConnectionError("still broken"))
+    responses.add(responses.GET, BODHI_URL, body=requests.exceptions.ConnectionError("still broken"))
+    with pytest.raises(BodhiLookupError):
+        get_current_stable_branch()
+
+
+@responses.activate
+def test_raises_bodhi_lookup_error_when_no_current_release_found():
+    responses.add(responses.GET, BODHI_URL, json={"releases": []}, status=200)
+    with pytest.raises(BodhiLookupError):
+        get_current_stable_branch()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater/test_fedora_release.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'fedora_flatpak_updater.fedora_release'`.
+
+- [ ] **Step 3: Implement `fedora_release.py`**
+
+```python
+# scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/fedora_release.py
+from __future__ import annotations
+
+import requests
+from tenacity import retry, retry_if_exception_type, stop_after_attempt
+
+BODHI_RELEASES_URL = "https://bodhi.fedoraproject.org/releases/"
+
+
+class BodhiLookupError(RuntimeError):
+    """Raised when the current Fedora stable branch cannot be determined."""
+
+
+@retry(
+    retry=retry_if_exception_type(requests.RequestException),
+    stop=stop_after_attempt(2),  # 1 try + 1 retry
+    reraise=True,
+)
+def _fetch_releases(session: requests.Session) -> dict:
+    response = session.get(BODHI_RELEASES_URL, params={"state": "current"}, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+
+def get_current_stable_branch(session: requests.Session | None = None) -> str:
+    """Returns the current Fedora stable branch, e.g. "f44".
+
+    Queries Bodhi for releases with state=current, keeps only entries whose
+    id_prefix is exactly "FEDORA" (excluding *-CONTAINER/*-FLATPAK/*-EPEL*
+    variants) and that have already been released (`released_on` is set),
+    then returns the highest `version` among those.
+    """
+    session = session or requests.Session()
+    try:
+        payload = _fetch_releases(session)
+    except requests.RequestException as exc:
+        raise BodhiLookupError(f"Bodhi releases lookup failed: {exc}") from exc
+
+    candidates = [
+        release
+        for release in payload.get("releases", [])
+        if release.get("id_prefix") == "FEDORA"
+        and release.get("released_on")
+        and release.get("version") is not None
+    ]
+    if not candidates:
+        raise BodhiLookupError("No current, released Fedora releases found in Bodhi response")
+
+    newest = max(candidates, key=lambda release: int(release["version"]))
+    return f"f{newest['version']}"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater/test_fedora_release.py -v
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add Bodhi current-stable-branch lookup with tenacity retry"
+```
+
+---
+
+### Task 4: `mdapi_client.py` (via `tenacity`)
+
+**Files:**
+- Create: `scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/mdapi_client.py`
+- Test: `tests/fedora_flatpak_updater/test_mdapi_client.py`
+
+**Interfaces:**
+- Produces: `MdapiClient(branch, session=None)` with `.get_version(package_name) -> str`; `PackageNotFoundError(package_name, branch)`; `MdapiTransientError`. Consumed later by `cli.py` and `migrate.py`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/fedora_flatpak_updater/test_mdapi_client.py
+from __future__ import annotations
+
+import pytest
+import responses
+
+from fedora_flatpak_updater.mdapi_client import MdapiClient, MdapiTransientError, PackageNotFoundError
+
+
+@responses.activate
+def test_get_version_returns_version_field():
+    url = "https://mdapi.fedoraproject.org/f44/pkg/python3-cryptography"
+    responses.add(responses.GET, url, json={"version": "46.0.7"}, status=200)
+
+    client = MdapiClient("f44")
+    assert client.get_version("python3-cryptography") == "46.0.7"
+
+
+@responses.activate
+def test_get_version_caches_repeat_calls():
+    url = "https://mdapi.fedoraproject.org/f44/pkg/python3-cryptography"
+    responses.add(responses.GET, url, json={"version": "46.0.7"}, status=200)
+
+    client = MdapiClient("f44")
+    client.get_version("python3-cryptography")
+    client.get_version("python3-cryptography")
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_get_version_raises_package_not_found_on_404():
+    url = "https://mdapi.fedoraproject.org/f44/pkg/python3-does-not-exist"
+    responses.add(responses.GET, url, status=404)
+
+    client = MdapiClient("f44")
+    with pytest.raises(PackageNotFoundError):
+        client.get_version("python3-does-not-exist")
+
+
+@responses.activate
+def test_get_version_retries_once_on_5xx_then_succeeds():
+    url = "https://mdapi.fedoraproject.org/f44/pkg/libndp"
+    responses.add(responses.GET, url, status=502)
+    responses.add(responses.GET, url, json={"version": "1.10"}, status=200)
+
+    client = MdapiClient("f44")
+    assert client.get_version("libndp") == "1.10"
+
+
+@responses.activate
+def test_get_version_raises_transient_error_after_two_5xx():
+    url = "https://mdapi.fedoraproject.org/f44/pkg/libndp"
+    responses.add(responses.GET, url, status=502)
+    responses.add(responses.GET, url, status=502)
+
+    client = MdapiClient("f44")
+    with pytest.raises(MdapiTransientError):
+        client.get_version("libndp")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater/test_mdapi_client.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'fedora_flatpak_updater.mdapi_client'`.
+
+- [ ] **Step 3: Implement `mdapi_client.py`**
+
+```python
+# scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/mdapi_client.py
+from __future__ import annotations
+
+import requests
+from tenacity import retry, retry_if_exception_type, stop_after_attempt
+
+MDAPI_BASE = "https://mdapi.fedoraproject.org"
+
+
+class PackageNotFoundError(Exception):
+    def __init__(self, package_name: str, branch: str):
+        super().__init__(f"{package_name} not found in Fedora {branch}")
+        self.package_name = package_name
+        self.branch = branch
+
+
+class MdapiTransientError(RuntimeError):
+    """Raised when MDAPI returns a server error even after one retry."""
+
+
+class MdapiClient:
+    """Thin client for mdapi.fedoraproject.org/<branch>/pkg/<name>, with a
+    per-instance in-memory cache."""
+
+    def __init__(self, branch: str, session: requests.Session | None = None):
+        self.branch = branch
+        self.session = session or requests.Session()
+        self._cache: dict[str, str] = {}
+
+    def get_version(self, package_name: str) -> str:
+        if package_name in self._cache:
+            return self._cache[package_name]
+
+        url = f"{MDAPI_BASE}/{self.branch}/pkg/{package_name}"
+        response = self._get_with_retry(url)
+
+        if response.status_code == 404:
+            raise PackageNotFoundError(package_name, self.branch)
+        response.raise_for_status()
+
+        version = response.json()["version"]
+        self._cache[package_name] = version
+        return version
+
+    @retry(
+        retry=retry_if_exception_type(MdapiTransientError),
+        stop=stop_after_attempt(2),  # 1 try + 1 retry
+        reraise=True,
+    )
+    def _get_with_retry(self, url: str) -> requests.Response:
+        response = self.session.get(url, timeout=30)
+        if response.status_code >= 500:
+            raise MdapiTransientError(f"{url} returned {response.status_code}")
+        return response
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater/test_mdapi_client.py -v
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add MDAPI client with caching and tenacity-based 5xx retry"
+```
+
+---
+
+### Task 5: `models.py` + `mapping_loader.py`
+
+**Files:**
+- Create: `scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/models.py`
+- Create: `scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/mapping_loader.py`
+- Test: `tests/fedora_flatpak_updater/test_mapping_loader.py`
+
+**Interfaces:**
+- Produces: `RecipeKind` enum (`PYPI="pypi"`, `PYPI_MULTI_WHEEL="pypi-multi-wheel"`, `ARCHIVE="archive"`, `GIT="git"`); `ModuleSpec` frozen dataclass with fields `name, fedora_package, recipe, pypi_name=None, prefer="wheel", wheel_arches=(), url_template=None, repo_url=None, tag_template=None, tag_pattern=None, manual_followup=None`; `load_mapping(path) -> list[ModuleSpec]`; `MappingError`. Consumed by `manifest_patcher.py` and `cli.py`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/fedora_flatpak_updater/test_mapping_loader.py
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fedora_flatpak_updater.mapping_loader import MappingError, load_mapping
+from fedora_flatpak_updater.models import RecipeKind
+
+
+def test_load_mapping_parses_all_recipe_kinds(tmp_path: Path):
+    mapping_file = tmp_path / ".fedora-tracked-modules.yaml"
+    mapping_file.write_text(
+        """
+modules:
+  python3-idna:
+    fedora_package: python3-idna
+    recipe: pypi
+    pypi_name: idna
+    prefer: wheel
+  python3-cryptography:
+    fedora_package: python3-cryptography
+    recipe: pypi-multi-wheel
+    pypi_name: cryptography
+    wheel_arches: [aarch64, x86_64]
+  libndp:
+    fedora_package: libndp
+    recipe: archive
+    url_template: "https://github.com/jpirko/libndp/archive/v$version.tar.gz"
+  NetworkManager:
+    fedora_package: NetworkManager
+    recipe: git
+    repo_url: "https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git"
+    tag_template: "$version"
+  python3-bcrypt:
+    fedora_package: python3-bcrypt
+    recipe: pypi
+    pypi_name: bcrypt
+    manual_followup: "regenerate bcrypt-cargo-sources.json"
+"""
+    )
+
+    specs = load_mapping(mapping_file)
+    by_name = {spec.name: spec for spec in specs}
+
+    assert by_name["python3-idna"].recipe == RecipeKind.PYPI
+    assert by_name["python3-idna"].pypi_name == "idna"
+
+    assert by_name["python3-cryptography"].recipe == RecipeKind.PYPI_MULTI_WHEEL
+    assert by_name["python3-cryptography"].wheel_arches == ("aarch64", "x86_64")
+
+    assert by_name["libndp"].recipe == RecipeKind.ARCHIVE
+    assert by_name["libndp"].url_template.endswith("v$version.tar.gz")
+
+    assert by_name["NetworkManager"].recipe == RecipeKind.GIT
+    assert by_name["NetworkManager"].tag_template == "$version"
+
+    assert by_name["python3-bcrypt"].manual_followup == "regenerate bcrypt-cargo-sources.json"
+
+
+def test_load_mapping_rejects_missing_recipe(tmp_path: Path):
+    mapping_file = tmp_path / ".fedora-tracked-modules.yaml"
+    mapping_file.write_text(
+        """
+modules:
+  broken:
+    fedora_package: broken
+"""
+    )
+    with pytest.raises(MappingError):
+        load_mapping(mapping_file)
+
+
+def test_load_mapping_rejects_missing_fedora_package(tmp_path: Path):
+    mapping_file = tmp_path / ".fedora-tracked-modules.yaml"
+    mapping_file.write_text(
+        """
+modules:
+  broken:
+    recipe: pypi
+    pypi_name: broken
+"""
+    )
+    with pytest.raises(MappingError):
+        load_mapping(mapping_file)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater/test_mapping_loader.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'fedora_flatpak_updater.mapping_loader'`.
+
+- [ ] **Step 3: Implement `models.py`**
+
+```python
+# scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/models.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class RecipeKind(str, Enum):
+    PYPI = "pypi"
+    PYPI_MULTI_WHEEL = "pypi-multi-wheel"
+    ARCHIVE = "archive"
+    GIT = "git"
+
+
+@dataclass(frozen=True)
+class ModuleSpec:
+    """One entry from .fedora-tracked-modules.yaml."""
+
+    name: str
+    fedora_package: str
+    recipe: RecipeKind
+    pypi_name: str | None = None
+    prefer: str = "wheel"
+    wheel_arches: tuple[str, ...] = ()
+    url_template: str | None = None
+    repo_url: str | None = None
+    tag_template: str | None = None
+    tag_pattern: str | None = None
+    manual_followup: str | None = None
+```
+
+- [ ] **Step 4: Implement `mapping_loader.py`**
+
+```python
+# scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/mapping_loader.py
+from __future__ import annotations
+
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+from .models import ModuleSpec, RecipeKind
+
+_yaml = YAML(typ="safe")
+
+
+class MappingError(ValueError):
+    """Raised when .fedora-tracked-modules.yaml is malformed."""
+
+
+def load_mapping(path: Path) -> list[ModuleSpec]:
+    with Path(path).open("r", encoding="utf-8") as fh:
+        raw = _yaml.load(fh) or {}
+
+    modules = raw.get("modules") or {}
+    specs: list[ModuleSpec] = []
+    for name, entry in modules.items():
+        if not isinstance(entry, dict):
+            raise MappingError(f"{name}: entry must be a mapping")
+        try:
+            recipe = RecipeKind(entry["recipe"])
+        except (KeyError, ValueError) as exc:
+            raise MappingError(f"{name}: invalid or missing 'recipe'") from exc
+        if "fedora_package" not in entry:
+            raise MappingError(f"{name}: missing 'fedora_package'")
+
+        specs.append(
+            ModuleSpec(
+                name=name,
+                fedora_package=entry["fedora_package"],
+                recipe=recipe,
+                pypi_name=entry.get("pypi_name"),
+                prefer=entry.get("prefer", "wheel"),
+                wheel_arches=tuple(entry.get("wheel_arches", ())),
+                url_template=entry.get("url_template"),
+                repo_url=entry.get("repo_url"),
+                tag_template=entry.get("tag_template"),
+                tag_pattern=entry.get("tag_pattern"),
+                manual_followup=entry.get("manual_followup"),
+            )
+        )
+    return specs
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater/test_mapping_loader.py -v
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add ModuleSpec/RecipeKind models and mapping file loader"
+```
+
+---
+
+### Task 6: `recipes/pypi.py`
+
+**Files:**
+- Create: `scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/pypi.py`
+- Test: `tests/fedora_flatpak_updater/test_recipes_pypi.py`
+
+**Interfaces:**
+- Produces: `PypiSource(url, sha256, only_arches=())` dataclass; `resolve_wheel`, `resolve_sdist`, `resolve(pypi_name, version, *, prefer="wheel", session=None)`, `resolve_multi_wheel(pypi_name, version, wheel_arches, session=None) -> dict[str, PypiSource]`; `PypiVersionNotFoundError`. Consumed by `cli.py`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/fedora_flatpak_updater/test_recipes_pypi.py
+from __future__ import annotations
+
+import pytest
+import responses
+
+from fedora_flatpak_updater.recipes.pypi import (
+    PypiVersionNotFoundError,
+    resolve,
+    resolve_multi_wheel,
+    resolve_sdist,
+    resolve_wheel,
+)
+
+IDNA_URL = "https://pypi.org/pypi/idna/3.11/json"
+IDNA_JSON = {
+    "urls": [
+        {
+            "packagetype": "sdist",
+            "url": "https://files.pythonhosted.org/packages/.../idna-3.11.tar.gz",
+            "digests": {"sha256": "sdist" + "0" * 59},
+        },
+        {
+            "packagetype": "bdist_wheel",
+            "filename": "idna-3.11-py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/.../idna-3.11-py3-none-any.whl",
+            "digests": {"sha256": "wheel" + "0" * 59},
+        },
+    ]
+}
+
+CRYPTOGRAPHY_URL = "https://pypi.org/pypi/cryptography/46.0.7/json"
+CRYPTOGRAPHY_JSON = {
+    "urls": [
+        {
+            "packagetype": "bdist_wheel",
+            "filename": "cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl",
+            "url": "https://files.pythonhosted.org/.../cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl",
+            "digests": {"sha256": "aarch64" + "0" * 57},
+        },
+        {
+            "packagetype": "bdist_wheel",
+            "filename": "cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl",
+            "url": "https://files.pythonhosted.org/.../cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl",
+            "digests": {"sha256": "x86_64" + "0" * 58},
+        },
+    ]
+}
+
+
+@responses.activate
+def test_resolve_wheel_picks_bdist_wheel_entry():
+    responses.add(responses.GET, IDNA_URL, json=IDNA_JSON, status=200)
+    source = resolve_wheel("idna", "3.11")
+    assert source.url.endswith(".whl")
+    assert source.sha256.startswith("wheel")
+
+
+@responses.activate
+def test_resolve_sdist_picks_sdist_entry():
+    responses.add(responses.GET, IDNA_URL, json=IDNA_JSON, status=200)
+    source = resolve_sdist("idna", "3.11")
+    assert source.url.endswith(".tar.gz")
+    assert source.sha256.startswith("sdist")
+
+
+@responses.activate
+def test_resolve_prefers_wheel_by_default():
+    responses.add(responses.GET, IDNA_URL, json=IDNA_JSON, status=200)
+    source = resolve("idna", "3.11")
+    assert source.url.endswith(".whl")
+
+
+@responses.activate
+def test_resolve_falls_back_to_sdist_when_no_wheel_available():
+    payload = {"urls": [IDNA_JSON["urls"][0]]}  # sdist only
+    responses.add(responses.GET, IDNA_URL, json=payload, status=200)
+    source = resolve("idna", "3.11", prefer="wheel")
+    assert source.url.endswith(".tar.gz")
+
+
+@responses.activate
+def test_resolve_raises_when_version_missing_on_pypi():
+    responses.add(responses.GET, "https://pypi.org/pypi/idna/999.0/json", status=404)
+    with pytest.raises(PypiVersionNotFoundError):
+        resolve("idna", "999.0")
+
+
+@responses.activate
+def test_resolve_multi_wheel_selects_one_wheel_per_arch():
+    responses.add(responses.GET, CRYPTOGRAPHY_URL, json=CRYPTOGRAPHY_JSON, status=200)
+    result = resolve_multi_wheel("cryptography", "46.0.7", ("aarch64", "x86_64"))
+    assert result["aarch64"].sha256.startswith("aarch64")
+    assert result["x86_64"].sha256.startswith("x86_64")
+    assert result["aarch64"].only_arches == ("aarch64",)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater/test_recipes_pypi.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'fedora_flatpak_updater.recipes.pypi'`.
+
+- [ ] **Step 3: Implement `recipes/pypi.py`**
+
+```python
+# scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/pypi.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import requests
+
+PYPI_BASE = "https://pypi.org/pypi"
+
+
+class PypiVersionNotFoundError(RuntimeError):
+    """Raised when a specific pypi_name==version has no usable distribution."""
+
+
+@dataclass(frozen=True)
+class PypiSource:
+    url: str
+    sha256: str
+    only_arches: tuple[str, ...] = ()
+
+
+def fetch_release_files(pypi_name: str, version: str, session: requests.Session | None = None) -> list[dict]:
+    session = session or requests.Session()
+    url = f"{PYPI_BASE}/{pypi_name}/{version}/json"
+    response = session.get(url, timeout=30)
+    if response.status_code == 404:
+        raise PypiVersionNotFoundError(f"{pypi_name}=={version} not found on PyPI")
+    response.raise_for_status()
+    return response.json()["urls"]
+
+
+def resolve_wheel(pypi_name: str, version: str, session: requests.Session | None = None) -> PypiSource:
+    for file_info in fetch_release_files(pypi_name, version, session):
+        if file_info["packagetype"] == "bdist_wheel":
+            return PypiSource(url=file_info["url"], sha256=file_info["digests"]["sha256"])
+    raise PypiVersionNotFoundError(f"No wheel for {pypi_name}=={version}")
+
+
+def resolve_sdist(pypi_name: str, version: str, session: requests.Session | None = None) -> PypiSource:
+    for file_info in fetch_release_files(pypi_name, version, session):
+        if file_info["packagetype"] == "sdist":
+            return PypiSource(url=file_info["url"], sha256=file_info["digests"]["sha256"])
+    raise PypiVersionNotFoundError(f"No sdist for {pypi_name}=={version}")
+
+
+def resolve(
+    pypi_name: str,
+    version: str,
+    *,
+    prefer: str = "wheel",
+    session: requests.Session | None = None,
+) -> PypiSource:
+    primary, fallback = (resolve_wheel, resolve_sdist) if prefer == "wheel" else (resolve_sdist, resolve_wheel)
+    try:
+        return primary(pypi_name, version, session)
+    except PypiVersionNotFoundError:
+        return fallback(pypi_name, version, session)
+
+
+def resolve_multi_wheel(
+    pypi_name: str,
+    version: str,
+    wheel_arches: tuple[str, ...],
+    session: requests.Session | None = None,
+) -> dict[str, PypiSource]:
+    """The `cryptography` case: one manylinux wheel per architecture."""
+    files = fetch_release_files(pypi_name, version, session)
+    result: dict[str, PypiSource] = {}
+    for arch in wheel_arches:
+        for file_info in files:
+            if file_info["packagetype"] != "bdist_wheel":
+                continue
+            filename = file_info["filename"]
+            if arch in filename and "manylinux" in filename:
+                result[arch] = PypiSource(
+                    url=file_info["url"],
+                    sha256=file_info["digests"]["sha256"],
+                    only_arches=(arch,),
+                )
+                break
+        else:
+            raise PypiVersionNotFoundError(f"No wheel for {pypi_name}=={version} arch={arch}")
+    return result
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater/test_recipes_pypi.py -v
+```
+
+Expected: 6 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add pypi recipe (wheel/sdist/multi-wheel resolution)"
+```
+
+---
+
+### Task 7: `recipes/archive.py`
+
+**Files:**
+- Create: `scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/archive.py`
+- Test: `tests/fedora_flatpak_updater/test_recipes_archive.py`
+
+**Interfaces:**
+- Produces: `ArchiveSource(url, sha256)` dataclass; `render_url(url_template, version) -> str`; `resolve(url_template, version, session=None) -> ArchiveSource`; `ArchiveResolutionError`. Consumed by `cli.py`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/fedora_flatpak_updater/test_recipes_archive.py
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+import responses
+
+from fedora_flatpak_updater.recipes.archive import ArchiveResolutionError, render_url, resolve
+
+
+def test_render_url_substitutes_version():
+    rendered = render_url("https://github.com/jpirko/libndp/archive/v$version.tar.gz", "1.10")
+    assert rendered == "https://github.com/jpirko/libndp/archive/v1.10.tar.gz"
+
+
+@responses.activate
+def test_resolve_computes_sha256_of_downloaded_content():
+    content = b"fake tarball bytes"
+    url = "https://github.com/jpirko/libndp/archive/v1.10.tar.gz"
+    responses.add(responses.GET, url, body=content, status=200)
+
+    source = resolve("https://github.com/jpirko/libndp/archive/v$version.tar.gz", "1.10")
+
+    assert source.url == url
+    assert source.sha256 == hashlib.sha256(content).hexdigest()
+
+
+@responses.activate
+def test_resolve_raises_on_404():
+    url = "https://gitlab.freedesktop.org/polkit/polkit/-/archive/127/polkit-127.tar.gz"
+    responses.add(responses.GET, url, status=404)
+
+    with pytest.raises(ArchiveResolutionError):
+        resolve(
+            "https://gitlab.freedesktop.org/polkit/polkit/-/archive/$version/polkit-$version.tar.gz",
+            "127",
+        )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater/test_recipes_archive.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'fedora_flatpak_updater.recipes.archive'`.
+
+- [ ] **Step 3: Implement `recipes/archive.py`**
+
+```python
+# scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/archive.py
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from string import Template
+
+import requests
+
+
+class ArchiveResolutionError(RuntimeError):
+    """Raised when a rendered archive URL cannot be fetched."""
+
+
+@dataclass(frozen=True)
+class ArchiveSource:
+    url: str
+    sha256: str
+
+
+def render_url(url_template: str, version: str) -> str:
+    return Template(url_template).substitute(version=version)
+
+
+def resolve(url_template: str, version: str, session: requests.Session | None = None) -> ArchiveSource:
+    session = session or requests.Session()
+    url = render_url(url_template, version)
+    response = session.get(url, timeout=60, stream=True)
+    if response.status_code == 404:
+        raise ArchiveResolutionError(f"{url} returned 404")
+    response.raise_for_status()
+
+    digest = hashlib.sha256()
+    for chunk in response.iter_content(chunk_size=65536):
+        digest.update(chunk)
+    return ArchiveSource(url=url, sha256=digest.hexdigest())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater/test_recipes_archive.py -v
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add archive recipe (url templating + sha256 download)"
+```
+
+---
+
+### Task 8: `recipes/git.py`
+
+**Files:**
+- Create: `scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/git.py`
+- Test: `tests/fedora_flatpak_updater/test_recipes_git.py`
+
+**Interfaces:**
+- Produces: `GitSource(tag, commit)` dataclass; `resolve(*, repo_url, version, tag_template=None, tag_pattern=None, runner=subprocess.run) -> GitSource`; `GitTagNotFoundError`. Consumed by `cli.py`.
+
+No HTTP is involved here (`git ls-remote` is a subprocess call), so `responses` doesn't apply — the injectable `runner` callable is already the simplest way to make this testable without a real network/git dependency.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/fedora_flatpak_updater/test_recipes_git.py
+from __future__ import annotations
+
+import pytest
+
+from fedora_flatpak_updater.recipes.git import GitTagNotFoundError, resolve
+
+NETWORKMANAGER_LS_REMOTE = (
+    "2db3748ec8162ce948ba52f71b42a258ff8d64ba\trefs/tags/1.40.18\n"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\trefs/tags/1.54.3\n"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\trefs/tags/1.54.3^{}\n"
+)
+
+SYSTEMD_LS_REMOTE = (
+    "cccccccccccccccccccccccccccccccccccccccc\trefs/tags/v259.0\n"
+    "dddddddddddddddddddddddddddddddddddddddd\trefs/tags/v260.2\n"
+    "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\trefs/tags/v260.2^{}\n"
+)
+
+
+class _FakeCompleted:
+    def __init__(self, stdout: str):
+        self.stdout = stdout
+
+
+def _runner_returning(stdout: str):
+    def runner(*args, **kwargs):
+        return _FakeCompleted(stdout)
+
+    return runner
+
+
+def test_resolve_by_tag_template_prefers_peeled_hash():
+    source = resolve(
+        repo_url="https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git",
+        version="1.54.3",
+        tag_template="$version",
+        runner=_runner_returning(NETWORKMANAGER_LS_REMOTE),
+    )
+    assert source.tag == "1.54.3"
+    assert source.commit == "b" * 40
+
+
+def test_resolve_by_tag_pattern_matches_captured_version():
+    source = resolve(
+        repo_url="https://github.com/systemd/systemd.git",
+        version="260.2",
+        tag_pattern=r"^v([\d.]+)$",
+        runner=_runner_returning(SYSTEMD_LS_REMOTE),
+    )
+    assert source.tag == "v260.2"
+    assert source.commit == "e" * 40
+
+
+def test_resolve_raises_when_tag_not_found():
+    with pytest.raises(GitTagNotFoundError):
+        resolve(
+            repo_url="https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git",
+            version="99.0.0",
+            tag_template="$version",
+            runner=_runner_returning(NETWORKMANAGER_LS_REMOTE),
+        )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater/test_recipes_git.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'fedora_flatpak_updater.recipes.git'`.
+
+- [ ] **Step 3: Implement `recipes/git.py`**
+
+```python
+# scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/git.py
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from string import Template
+
+
+class GitTagNotFoundError(RuntimeError):
+    """Raised when the target tag cannot be found on the remote."""
+
+
+@dataclass(frozen=True)
+class GitSource:
+    tag: str
+    commit: str
+
+
+def _ls_remote_tags(repo_url: str, runner) -> list[tuple[str, str]]:
+    result = runner(
+        ["git", "ls-remote", "--tags", repo_url],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    entries = []
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        sha, ref = line.split("\t", 1)
+        entries.append((sha, ref.strip()))
+    return entries
+
+
+def resolve(
+    *,
+    repo_url: str,
+    version: str,
+    tag_template: str | None = None,
+    tag_pattern: str | None = None,
+    runner=subprocess.run,
+) -> GitSource:
+    if not tag_template and not tag_pattern:
+        raise ValueError("Either tag_template or tag_pattern must be provided")
+
+    entries = _ls_remote_tags(repo_url, runner)
+
+    by_tag: dict[str, dict[str, str]] = {}
+    for sha, ref in entries:
+        if not ref.startswith("refs/tags/"):
+            continue
+        peeled = ref.endswith("^{}")
+        tag_name = ref[len("refs/tags/"):]
+        if peeled:
+            tag_name = tag_name[: -len("^{}")]
+        by_tag.setdefault(tag_name, {})["peeled" if peeled else "plain"] = sha
+
+    if tag_template:
+        target_tag = Template(tag_template).substitute(version=version)
+    else:
+        pattern = re.compile(tag_pattern)
+        target_tag = None
+        for tag_name in by_tag:
+            match = pattern.match(tag_name)
+            if match and match.group(1) == version:
+                target_tag = tag_name
+                break
+        if target_tag is None:
+            raise GitTagNotFoundError(
+                f"no tag matching {tag_pattern!r} for version {version} on {repo_url}"
+            )
+
+    hashes = by_tag.get(target_tag)
+    if not hashes:
+        raise GitTagNotFoundError(f"tried tag {target_tag!r} on {repo_url}, not found")
+
+    commit = hashes.get("peeled") or hashes.get("plain")
+    return GitSource(tag=target_tag, commit=commit)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater/test_recipes_git.py -v
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add git recipe (tag-template/tag-pattern + peeled hash resolution)"
+```
+
+---
+
+### Task 9: `manifest_patcher.py` (via `packaging.utils.canonicalize_name`)
+
+**Files:**
+- Create: `scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/manifest_patcher.py`
+- Test: `tests/fedora_flatpak_updater/test_manifest_patcher.py`
+- Fixture: `tests/fedora_flatpak_updater/fixtures/root.yml`
+- Fixture: `tests/fedora_flatpak_updater/fixtures/pip-resources.example.yaml`
+
+**Interfaces:**
+- Consumes: `fedora_flatpak_updater.models.ModuleSpec`, `fedora_flatpak_updater.recipes.pypi.PypiSource`, `fedora_flatpak_updater.recipes.archive.ArchiveSource`, `fedora_flatpak_updater.recipes.git.GitSource`, `packaging.utils.canonicalize_name`
+- Produces: `ManifestForest(root_path)` with `.iter_dicts()` and `.save() -> list[Path]`; `find_module_blocks(forest, module_name) -> list[dict]`; `find_pypi_source_blocks(forest, pypi_name) -> list[dict]`; `apply_pypi(forest, spec, resolve_block) -> PatchReport`; `apply_archive(forest, spec, source) -> PatchReport`; `apply_git(forest, spec, source) -> PatchReport`; `PatchReport(module_name, blocks_touched, files_touched)`. Consumed by `cli.py`.
+
+- [ ] **Step 1: Create the fixture files**
+
+```yaml
+# tests/fedora_flatpak_updater/fixtures/root.yml
+modules:
+  - name: python3-idna
+    buildsystem: simple
+    build-commands:
+      - pip3 install idna
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/94/16/idna-3.16-py3-none-any.whl
+        sha256: cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5
+        x-checker-data:
+          name: idna
+          packagetype: bdist_wheel
+          type: pypi
+
+  # keep me: comment that must survive patching
+  - name: libndp
+    buildsystem: autotools
+    cleanup:
+      - /bin
+      - /include
+    sources:
+      - type: archive
+        url: https://github.com/jpirko/libndp/archive/v1.9.tar.gz
+        sha256: e564f5914a6b1b799c3afa64c258824a801c1b79a29e2fe6525b682249c65261
+        x-checker-data:
+          type: anitya
+          project-id: 14944
+          url-template: https://github.com/jpirko/libndp/archive/v$version.tar.gz
+
+  - name: python-proton-core
+    buildsystem: simple
+    build-commands:
+      - pip3 install .
+    modules:
+      - pip-resources.example.yaml
+    sources:
+      - type: git
+        url: https://github.com/ProtonVPN/python-proton-core
+        tag: v0.7.0
+        commit: f7a178a99c3adc0e88c7f91d4db5371a052c4985
+```
+
+```yaml
+# tests/fedora_flatpak_updater/fixtures/pip-resources.example.yaml
+name: pip-resources.example
+build-commands: []
+buildsystem: simple
+modules:
+  - name: python3-requests
+    buildsystem: simple
+    build-commands:
+      - pip3 install requests
+    sources:
+      - &idna_anchor
+        type: file
+        url: https://files.pythonhosted.org/packages/94/16/idna-3.16-py3-none-any.whl
+        sha256: cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5
+        x-checker-data:
+          name: idna
+          packagetype: bdist_wheel
+          type: pypi
+      - type: file
+        url: https://files.pythonhosted.org/packages/a0/f4/requests-2.34.2-py3-none-any.whl
+        sha256: 2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0
+        x-checker-data:
+          name: requests
+          packagetype: bdist_wheel
+          type: pypi
+  - name: python3-flit_core
+    buildsystem: simple
+    build-commands:
+      - pip3 install flit_core
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/69/59/flit_core-3.12.0.tar.gz
+        sha256: 18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2
+        x-checker-data:
+          type: pypi
+          name: flit_core
+  - name: python3-flit_core_dup
+    buildsystem: simple
+    build-commands:
+      - pip3 install flit_core
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/69/59/flit_core-3.12.0.tar.gz
+        sha256: 18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2
+        x-checker-data:
+          type: pypi
+          name: flit_core
+      - *idna_anchor
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+```python
+# tests/fedora_flatpak_updater/test_manifest_patcher.py
+from __future__ import annotations
+
+from pathlib import Path
+
+from fedora_flatpak_updater.manifest_patcher import (
+    ManifestForest,
+    apply_archive,
+    apply_git,
+    apply_pypi,
+    find_module_blocks,
+    find_pypi_source_blocks,
+)
+from fedora_flatpak_updater.models import ModuleSpec, RecipeKind
+from fedora_flatpak_updater.recipes.archive import ArchiveSource
+from fedora_flatpak_updater.recipes.git import GitSource
+from fedora_flatpak_updater.recipes.pypi import PypiSource
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _fresh_forest(tmp_path: Path) -> ManifestForest:
+    for name in ("root.yml", "pip-resources.example.yaml"):
+        (tmp_path / name).write_text((FIXTURES / name).read_text())
+    return ManifestForest(tmp_path / "root.yml")
+
+
+def test_find_pypi_source_blocks_finds_every_occurrence_across_files(tmp_path):
+    forest = _fresh_forest(tmp_path)
+    blocks = find_pypi_source_blocks(forest, "idna")
+    assert len(blocks) == 2  # root.yml's own block + the shared anchor/alias block
+
+
+def test_apply_pypi_updates_every_occurrence_and_strips_checker_data(tmp_path):
+    forest = _fresh_forest(tmp_path)
+    spec = ModuleSpec(name="python3-idna", fedora_package="python3-idna", recipe=RecipeKind.PYPI, pypi_name="idna")
+    new_source = PypiSource(url="https://files.pythonhosted.org/idna-3.11-py3-none-any.whl", sha256="deadbeef")
+
+    report = apply_pypi(forest, spec, lambda block: new_source)
+
+    assert report.blocks_touched == 2
+    for block in find_pypi_source_blocks(forest, "idna"):
+        assert block["url"] == new_source.url
+        assert block["sha256"] == new_source.sha256
+        assert "x-checker-data" not in block
+
+
+def test_apply_pypi_leaves_unrelated_packages_untouched(tmp_path):
+    forest = _fresh_forest(tmp_path)
+    spec = ModuleSpec(name="python3-idna", fedora_package="python3-idna", recipe=RecipeKind.PYPI, pypi_name="idna")
+    apply_pypi(forest, spec, lambda block: PypiSource(url="https://x/idna-3.11-py3-none-any.whl", sha256="deadbeef"))
+
+    [requests_block] = find_pypi_source_blocks(forest, "requests")
+    assert requests_block["sha256"] == "2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"
+    assert requests_block["x-checker-data"]["name"] == "requests"
+
+
+def test_apply_pypi_updates_duplicate_module_occurrences_independently(tmp_path):
+    forest = _fresh_forest(tmp_path)
+    spec = ModuleSpec(name="python3-flit_core", fedora_package="python3-flit_core", recipe=RecipeKind.PYPI, pypi_name="flit_core")
+    new_source = PypiSource(url="https://x/flit_core-4.0.0.tar.gz", sha256="cafef00d")
+
+    report = apply_pypi(forest, spec, lambda block: new_source)
+
+    assert report.blocks_touched == 2
+    assert all(b["url"] == new_source.url for b in find_pypi_source_blocks(forest, "flit_core"))
+
+
+def test_apply_archive_updates_module_matched_by_name(tmp_path):
+    forest = _fresh_forest(tmp_path)
+    spec = ModuleSpec(
+        name="libndp",
+        fedora_package="libndp",
+        recipe=RecipeKind.ARCHIVE,
+        url_template="https://github.com/jpirko/libndp/archive/v$version.tar.gz",
+    )
+    source = ArchiveSource(url="https://github.com/jpirko/libndp/archive/v1.10.tar.gz", sha256="abc123")
+
+    report = apply_archive(forest, spec, source)
+
+    assert report.blocks_touched == 1
+    [module] = find_module_blocks(forest, "libndp")
+    [src] = module["sources"]
+    assert src["url"] == source.url
+    assert src["sha256"] == source.sha256
+    assert "x-checker-data" not in src
+
+
+def test_apply_git_updates_tag_and_commit(tmp_path):
+    forest = _fresh_forest(tmp_path)
+    spec = ModuleSpec(
+        name="python-proton-core",
+        fedora_package="python-proton-core",
+        recipe=RecipeKind.GIT,
+        repo_url="https://github.com/ProtonVPN/python-proton-core",
+        tag_template="v$version",
+    )
+    source = GitSource(tag="v0.8.0", commit="a" * 40)
+
+    report = apply_git(forest, spec, source)
+
+    assert report.blocks_touched == 1
+    [module] = find_module_blocks(forest, "python-proton-core")
+    [src] = module["sources"]
+    assert src["tag"] == "v0.8.0"
+    assert src["commit"] == "a" * 40
+
+
+def test_save_preserves_comments_and_unrelated_structure(tmp_path):
+    forest = _fresh_forest(tmp_path)
+    spec = ModuleSpec(name="python3-idna", fedora_package="python3-idna", recipe=RecipeKind.PYPI, pypi_name="idna")
+    apply_pypi(forest, spec, lambda block: PypiSource(url="https://x/idna-3.11-py3-none-any.whl", sha256="deadbeef"))
+    forest.save()
+
+    root_text = (tmp_path / "root.yml").read_text()
+    assert "keep me: comment that must survive patching" in root_text
+    assert "buildsystem: autotools" in root_text
+    assert "cleanup:" in root_text
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater/test_manifest_patcher.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'fedora_flatpak_updater.manifest_patcher'`.
+
+- [ ] **Step 4: Implement `manifest_patcher.py`**
+
+```python
+# scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/manifest_patcher.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from packaging.utils import canonicalize_name
+from ruamel.yaml import YAML
+
+
+def _matches_pypi_name(url: str, pypi_name: str) -> bool:
+    filename = url.rsplit("/", 1)[-1].lower()
+    canonical = str(canonicalize_name(pypi_name))  # PEP 503, e.g. "jaraco-classes"
+    prefixes = {
+        pypi_name.lower() + "-",
+        canonical + "-",
+        canonical.replace("-", "_") + "-",  # wheel filenames use underscores
+    }
+    return any(filename.startswith(prefix) for prefix in prefixes)
+
+
+def _iter_dicts(node: Any):
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _iter_dicts(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_dicts(item)
+
+
+@dataclass
+class PatchReport:
+    module_name: str
+    blocks_touched: int
+    files_touched: tuple[str, ...] = ()
+
+
+class ManifestForest:
+    """Loads the root manifest and every pip-resources.*.yaml it
+    (transitively) references as separate ruamel round-trip documents, keyed
+    by resolved Path, so each file can be re-serialized independently."""
+
+    def __init__(self, root_path: Path):
+        self._yaml = YAML(typ="rt")
+        self._yaml.preserve_quotes = True
+        self._yaml.width = 1_000_000  # never re-wrap lines we didn't touch
+        self.root_path = Path(root_path).resolve()
+        self.documents: dict[Path, Any] = {}
+        self._load(self.root_path)
+
+    def _load(self, path: Path) -> None:
+        if path in self.documents:
+            return
+        with path.open("r", encoding="utf-8") as fh:
+            data = self._yaml.load(fh)
+        self.documents[path] = data
+        self._discover_refs(data, path.parent)
+
+    def _discover_refs(self, node: Any, base_dir: Path) -> None:
+        if isinstance(node, dict):
+            modules = node.get("modules")
+            if isinstance(modules, list):
+                for item in modules:
+                    if isinstance(item, str):
+                        self._load((base_dir / item).resolve())
+                    elif isinstance(item, dict):
+                        self._discover_refs(item, base_dir)
+            for key, value in node.items():
+                if key == "modules":
+                    continue
+                self._discover_refs(value, base_dir)
+        elif isinstance(node, list):
+            for item in node:
+                self._discover_refs(item, base_dir)
+
+    def iter_dicts(self):
+        for data in self.documents.values():
+            yield from _iter_dicts(data)
+
+    def save(self) -> list[Path]:
+        written = []
+        for path, data in self.documents.items():
+            with path.open("w", encoding="utf-8") as fh:
+                self._yaml.dump(data, fh)
+            written.append(path)
+        return written
+
+
+def find_module_blocks(forest: ManifestForest, module_name: str) -> list[dict]:
+    """archive/git recipes: match standalone flatpak modules by `name:`."""
+    return [d for d in forest.iter_dicts() if d.get("name") == module_name and "sources" in d]
+
+
+def find_pypi_source_blocks(forest: ManifestForest, pypi_name: str) -> list[dict]:
+    """pypi/pypi-multi-wheel recipes: match source dicts by URL filename
+    prefix, since the same PyPI package routinely appears bundled inside
+    many differently-named carrier modules across the manifest forest."""
+    return [
+        d
+        for d in forest.iter_dicts()
+        if d.get("type") in ("file", "archive")
+        and isinstance(d.get("url"), str)
+        and _matches_pypi_name(d["url"], pypi_name)
+    ]
+
+
+def apply_pypi(forest: ManifestForest, spec, resolve_block: Callable[[dict], Any]) -> PatchReport:
+    """`resolve_block(current_block)` is called once per matched block so
+    each occurrence can be resolved according to its own existing shape
+    (wheel vs sdist, arch-specific vs generic)."""
+    blocks = find_pypi_source_blocks(forest, spec.pypi_name)
+    touched = 0
+    for block in blocks:
+        source = resolve_block(block)
+        if source is None:
+            continue
+        block["url"] = source.url
+        block["sha256"] = source.sha256
+        block.pop("x-checker-data", None)
+        touched += 1
+    return PatchReport(module_name=spec.name, blocks_touched=touched)
+
+
+def apply_archive(forest: ManifestForest, spec, source) -> PatchReport:
+    touched = 0
+    for module_block in find_module_blocks(forest, spec.name):
+        for src in module_block.get("sources", []):
+            if isinstance(src, dict) and src.get("type") == "archive":
+                src["url"] = source.url
+                src["sha256"] = source.sha256
+                src.pop("x-checker-data", None)
+                touched += 1
+    return PatchReport(module_name=spec.name, blocks_touched=touched)
+
+
+def apply_git(forest: ManifestForest, spec, source) -> PatchReport:
+    touched = 0
+    for module_block in find_module_blocks(forest, spec.name):
+        for src in module_block.get("sources", []):
+            if isinstance(src, dict) and src.get("type") == "git":
+                src["tag"] = source.tag
+                src["commit"] = source.commit
+                src.pop("x-checker-data", None)
+                touched += 1
+    return PatchReport(module_name=spec.name, blocks_touched=touched)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater/test_manifest_patcher.py -v
+```
+
+Expected: 7 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add ruamel-based manifest forest loader and patch functions"
+```
+
+---
+
+### Task 10: `cli.py` (via `click` + `tabulate`)
+
+**Files:**
+- Create: `scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/cli.py`
+- Test: `tests/fedora_flatpak_updater/test_cli.py`
+
+**Interfaces:**
+- Consumes: `fedora_release.get_current_stable_branch`, `fedora_release.BodhiLookupError`, `mdapi_client.MdapiClient`, `mdapi_client.PackageNotFoundError`, `mdapi_client.MdapiTransientError`, `mapping_loader.load_mapping`, `manifest_patcher.ManifestForest/apply_pypi/apply_archive/apply_git`, `models.RecipeKind`, `recipes.pypi`, `recipes.archive`, `recipes.git`, `click`, `tabulate.tabulate`
+- Produces: `Row(module_name, status, detail)`; `run(mapping_path, manifest_root, *, dry_run=False, only=None) -> list[Row]`; `format_summary(rows) -> str`; `main` (a `click.Command`, the package's console-script entry point). Consumed by the GitHub Actions workflow in Task 13.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/fedora_flatpak_updater/test_cli.py
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from fedora_flatpak_updater import cli
+from fedora_flatpak_updater.mdapi_client import PackageNotFoundError
+from fedora_flatpak_updater.recipes.archive import ArchiveSource
+from fedora_flatpak_updater.recipes.pypi import PypiSource
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class FakeMdapi:
+    _VERSIONS = {"python3-idna": "3.99", "libndp": "9.9"}
+
+    def __init__(self, branch, session=None):
+        self.branch = branch
+
+    def get_version(self, package_name):
+        if package_name not in self._VERSIONS:
+            raise PackageNotFoundError(package_name, self.branch)
+        return self._VERSIONS[package_name]
+
+
+@pytest.fixture
+def manifest_root(tmp_path):
+    for name in ("root.yml", "pip-resources.example.yaml"):
+        (tmp_path / name).write_text((FIXTURES / name).read_text())
+    return tmp_path / "root.yml"
+
+
+@pytest.fixture
+def mapping_file(tmp_path):
+    path = tmp_path / ".fedora-tracked-modules.yaml"
+    path.write_text(
+        """
+modules:
+  python3-idna:
+    fedora_package: python3-idna
+    recipe: pypi
+    pypi_name: idna
+  libndp:
+    fedora_package: libndp
+    recipe: archive
+    url_template: "https://github.com/jpirko/libndp/archive/v$version.tar.gz"
+  python3-nonexistent:
+    fedora_package: python3-nonexistent
+    recipe: pypi
+    pypi_name: nonexistent
+"""
+    )
+    return path
+
+
+def _patch_common(monkeypatch):
+    monkeypatch.setattr(cli, "get_current_stable_branch", lambda session=None: "f44")
+    monkeypatch.setattr(cli, "MdapiClient", FakeMdapi)
+    monkeypatch.setattr(
+        cli.pypi_recipe,
+        "resolve",
+        lambda pypi_name, version, prefer="wheel", session=None: PypiSource(
+            url=f"https://x/{pypi_name}-{version}-py3-none-any.whl", sha256="deadbeef"
+        ),
+    )
+    monkeypatch.setattr(
+        cli.archive_recipe,
+        "resolve",
+        lambda url_template, version, session=None: ArchiveSource(
+            url=f"https://x/libndp-{version}.tar.gz", sha256="cafef00d"
+        ),
+    )
+
+
+def test_run_reports_updated_and_skipped_modules(monkeypatch, manifest_root, mapping_file):
+    _patch_common(monkeypatch)
+
+    rows = cli.run(mapping_file, manifest_root, dry_run=True)
+
+    statuses = {row.module_name: row.status for row in rows}
+    assert statuses["python3-idna"] == "updated"
+    assert statuses["libndp"] == "updated"
+    assert statuses["python3-nonexistent"] == "skipped"
+
+
+def test_dry_run_does_not_write_files(monkeypatch, manifest_root, mapping_file):
+    _patch_common(monkeypatch)
+    original_text = manifest_root.read_text()
+
+    cli.run(mapping_file, manifest_root, dry_run=True, only=["python3-idna"])
+
+    assert manifest_root.read_text() == original_text
+
+
+def test_non_dry_run_writes_updated_files(monkeypatch, manifest_root, mapping_file):
+    _patch_common(monkeypatch)
+
+    cli.run(mapping_file, manifest_root, dry_run=False, only=["python3-idna"])
+
+    assert "idna-3.99-py3-none-any.whl" in manifest_root.read_text()
+
+
+def test_format_summary_produces_a_github_markdown_table(monkeypatch, manifest_root, mapping_file):
+    _patch_common(monkeypatch)
+    rows = cli.run(mapping_file, manifest_root, dry_run=True)
+
+    summary = cli.format_summary(rows)
+
+    assert "| Module" in summary
+    assert "python3-idna" in summary
+    assert "python3-nonexistent" in summary
+
+
+def test_main_command_wires_flags_into_run(monkeypatch, manifest_root, mapping_file):
+    captured = {}
+
+    def fake_run(mapping, manifest, *, dry_run=False, only=None):
+        captured["dry_run"] = dry_run
+        captured["only"] = only
+        return [cli.Row("python3-idna", "updated", "-> 3.99 (1 block(s))")]
+
+    monkeypatch.setattr(cli, "run", fake_run)
+
+    result = CliRunner().invoke(
+        cli.main,
+        [
+            "--mapping", str(mapping_file),
+            "--manifest", str(manifest_root),
+            "--dry-run",
+            "--only", "python3-idna",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "python3-idna" in result.output
+    assert captured["dry_run"] is True
+    assert captured["only"] == ["python3-idna"]
+
+
+def test_main_command_exits_nonzero_on_bodhi_failure(monkeypatch, manifest_root, mapping_file):
+    def raise_bodhi_error(mapping, manifest, *, dry_run=False, only=None):
+        raise cli.BodhiLookupError("Bodhi is down")
+
+    monkeypatch.setattr(cli, "run", raise_bodhi_error)
+
+    result = CliRunner().invoke(cli.main, ["--mapping", str(mapping_file), "--manifest", str(manifest_root)])
+
+    assert result.exit_code == 1
+    assert "Bodhi is down" in result.output
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater/test_cli.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'fedora_flatpak_updater.cli'`.
+
+- [ ] **Step 3: Implement `cli.py`**
+
+```python
+# scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/cli.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import click
+import requests
+from tabulate import tabulate
+
+from .fedora_release import BodhiLookupError, get_current_stable_branch
+from .manifest_patcher import ManifestForest, apply_archive, apply_git, apply_pypi
+from .mapping_loader import load_mapping
+from .mdapi_client import MdapiClient, MdapiTransientError, PackageNotFoundError
+from .models import ModuleSpec, RecipeKind
+from .recipes import archive as archive_recipe
+from .recipes import git as git_recipe
+from .recipes import pypi as pypi_recipe
+from .recipes.archive import ArchiveResolutionError
+from .recipes.git import GitTagNotFoundError
+from .recipes.pypi import PypiVersionNotFoundError
+
+
+@dataclass
+class Row:
+    module_name: str
+    status: str  # "updated" | "unchanged" | "skipped"
+    detail: str
+
+
+def _infer_prefer(url: str, fallback: str) -> str:
+    if url.endswith(".whl"):
+        return "wheel"
+    if url.endswith((".tar.gz", ".tar.bz2", ".zip")):
+        return "sdist"
+    return fallback
+
+
+def _resolve_pypi_block(
+    block: dict,
+    spec: ModuleSpec,
+    fedora_version: str,
+    session: requests.Session,
+    multi_wheel_cache: dict,
+):
+    if spec.recipe == RecipeKind.PYPI_MULTI_WHEEL and block.get("only-arches"):
+        arch = block["only-arches"][0]
+        cache_key = (spec.pypi_name, fedora_version)
+        if cache_key not in multi_wheel_cache:
+            multi_wheel_cache[cache_key] = pypi_recipe.resolve_multi_wheel(
+                spec.pypi_name, fedora_version, spec.wheel_arches, session=session
+            )
+        return multi_wheel_cache[cache_key].get(arch)
+
+    prefer = _infer_prefer(block.get("url", ""), spec.prefer)
+    return pypi_recipe.resolve(spec.pypi_name, fedora_version, prefer=prefer, session=session)
+
+
+def run(
+    mapping_path: Path,
+    manifest_root: Path,
+    *,
+    dry_run: bool = False,
+    only: list[str] | None = None,
+) -> list[Row]:
+    session = requests.Session()
+    branch = get_current_stable_branch(session=session)
+    specs = load_mapping(mapping_path)
+    if only:
+        specs = [spec for spec in specs if spec.name in only]
+
+    forest = ManifestForest(manifest_root)
+    mdapi = MdapiClient(branch, session=session)
+    multi_wheel_cache: dict = {}
+    rows: list[Row] = []
+
+    for spec in specs:
+        try:
+            fedora_version = mdapi.get_version(spec.fedora_package)
+        except (PackageNotFoundError, MdapiTransientError) as exc:
+            rows.append(Row(spec.name, "skipped", str(exc)))
+            continue
+
+        try:
+            if spec.recipe in (RecipeKind.PYPI, RecipeKind.PYPI_MULTI_WHEEL):
+                report = apply_pypi(
+                    forest,
+                    spec,
+                    lambda block: _resolve_pypi_block(block, spec, fedora_version, session, multi_wheel_cache),
+                )
+            elif spec.recipe == RecipeKind.ARCHIVE:
+                source = archive_recipe.resolve(spec.url_template, fedora_version, session=session)
+                report = apply_archive(forest, spec, source)
+            elif spec.recipe == RecipeKind.GIT:
+                source = git_recipe.resolve(
+                    repo_url=spec.repo_url,
+                    version=fedora_version,
+                    tag_template=spec.tag_template,
+                    tag_pattern=spec.tag_pattern,
+                )
+                report = apply_git(forest, spec, source)
+            else:  # pragma: no cover - RecipeKind is exhaustive
+                rows.append(Row(spec.name, "skipped", f"unknown recipe {spec.recipe}"))
+                continue
+        except (PypiVersionNotFoundError, ArchiveResolutionError, GitTagNotFoundError) as exc:
+            rows.append(Row(spec.name, "skipped", str(exc)))
+            continue
+
+        if report.blocks_touched == 0:
+            rows.append(Row(spec.name, "unchanged", f"no matching source blocks found for {fedora_version}"))
+        else:
+            detail = f"-> {fedora_version} ({report.blocks_touched} block(s))"
+            if spec.manual_followup:
+                detail += f" [manual follow-up: {spec.manual_followup}]"
+            rows.append(Row(spec.name, "updated", detail))
+
+    if not dry_run and any(row.status == "updated" for row in rows):
+        forest.save()
+
+    return rows
+
+
+def format_summary(rows: list[Row]) -> str:
+    table = [[row.module_name, row.status, row.detail] for row in rows]
+    return tabulate(table, headers=["Module", "Status", "Detail"], tablefmt="github")
+
+
+@click.command()
+@click.option(
+    "--mapping",
+    type=click.Path(path_type=Path),
+    default=Path(".fedora-tracked-modules.yaml"),
+    show_default=True,
+    help="Path to the tracked-modules mapping file.",
+)
+@click.option(
+    "--manifest",
+    type=click.Path(path_type=Path),
+    default=Path("com.protonvpn.www.yml"),
+    show_default=True,
+    help="Path to the root Flatpak manifest.",
+)
+@click.option("--dry-run", is_flag=True, default=False, help="Resolve and report without writing files.")
+@click.option("--only", multiple=True, help="Limit to specific tracked module name(s). Repeatable.")
+def main(mapping: Path, manifest: Path, dry_run: bool, only: tuple[str, ...]) -> None:
+    """Pin Flatpak manifest dependencies to Fedora-stable versions."""
+    try:
+        rows = run(mapping, manifest, dry_run=dry_run, only=list(only) or None)
+    except BodhiLookupError as exc:
+        click.echo(f"ERROR: {exc}", err=True)
+        raise SystemExit(1)
+
+    click.echo(format_summary(rows))
+    if not any(row.status == "updated" for row in rows):
+        click.echo("\nNothing to update.")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater/test_cli.py -v
+```
+
+Expected: 6 passed.
+
+- [ ] **Step 5: Run the full test suite**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater -v
+```
+
+Expected: all tests across every task pass (roughly 35-40 total).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add CLI orchestration (click command, tabulate summary)"
+```
+
+---
+
+### Task 11: Build the initial `.fedora-tracked-modules.yaml`
+
+**Files:**
+- Create: `scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/migrate.py`
+- Create: `.fedora-tracked-modules.yaml` (repo root)
+
+**Interfaces:**
+- Consumes: `fedora_release.get_current_stable_branch`, `mdapi_client.MdapiClient`, `mdapi_client.PackageNotFoundError`, `packaging.utils.canonicalize_name`, `click`
+- Produces: `.fedora-tracked-modules.yaml`, consumed by `mapping_loader.load_mapping` in every subsequent CLI run (Task 12, Task 13).
+
+- [ ] **Step 1: Implement `migrate.py`**
+
+This is a one-off helper, not part of the scheduled job — it prints a draft mapping to stdout for a human to review.
+
+```python
+# scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/migrate.py
+"""One-off helper for building the initial .fedora-tracked-modules.yaml.
+
+Walks the manifest forest, collects every distinct third-party PyPI
+`x-checker-data.name` value plus the known native archive/git modules,
+guesses a Fedora package name for each, and verifies the guess against
+MDAPI (including a HEAD check for archive url_templates, since the design
+doc's `polkit` case shows a stale template resolving to a 404). Prints a
+YAML draft to stdout; a human reviews it, hand-fixes anything flagged
+`_needs_manual_fix`, and saves the result to .fedora-tracked-modules.yaml.
+
+Not part of the ongoing scheduled job — run manually only when rebuilding
+the mapping from scratch (e.g. after adding a new dependency).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from string import Template
+from typing import Any
+
+import click
+import requests
+from packaging.utils import canonicalize_name
+from ruamel.yaml import YAML
+
+from .fedora_release import get_current_stable_branch
+from .mdapi_client import MdapiClient, PackageNotFoundError
+
+PROTON_PREFIX = "proton"
+
+NATIVE_MODULE_HINTS: dict[str, dict] = {
+    "libndp": {
+        "recipe": "archive",
+        "url_template": "https://github.com/jpirko/libndp/archive/v$version.tar.gz",
+    },
+    "polkit": {
+        "recipe": "archive",
+        "url_template": "https://github.com/polkit-org/polkit/archive/refs/tags/$version.tar.gz",
+    },
+    "libnma": {
+        "recipe": "archive",
+        "url_template": "https://gitlab.gnome.org/GNOME/libnma/-/archive/$version/libnma-$version.tar.gz",
+    },
+    "iproute2": {
+        "recipe": "archive",
+        "url_template": "https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-$version.tar.xz",
+    },
+    "python-dbus": {
+        "recipe": "archive",
+        "fedora_package": "dbus-python",
+        "url_template": "https://dbus.freedesktop.org/releases/dbus-python/dbus-python-$version.tar.gz",
+    },
+    "NetworkManager": {
+        "recipe": "git",
+        "repo_url": "https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git",
+        "tag_template": "$version",
+    },
+    "NetworkManager-openvpn": {
+        "recipe": "git",
+        "repo_url": "https://github.com/NetworkManager/NetworkManager-openvpn.git",
+        "tag_template": "$version",
+    },
+    "systemd": {
+        "recipe": "git",
+        "repo_url": "https://github.com/systemd/systemd.git",
+        "tag_pattern": r"^v([\d.]+)$",
+    },
+}
+
+MANUAL_FOLLOWUP = {
+    "python3-bcrypt": (
+        "bcrypt vendors Rust crate sources in bcrypt-cargo-sources.json. "
+        "Re-run flatpak-cargo-generator against the new version's Cargo.lock "
+        "before merging."
+    ),
+}
+
+# Known guess-convention exceptions (design doc item 6).
+FEDORA_NAME_OVERRIDES = {
+    "pycairo": "python3-cairo",
+    "pygobject": "python3-gobject",
+}
+
+
+def _iter_dicts(node: Any):
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _iter_dicts(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_dicts(item)
+
+
+def _load_forest(root_path: Path) -> list[Any]:
+    yaml = YAML(typ="safe")
+    documents = []
+    seen: set[Path] = set()
+
+    def load(path: Path) -> None:
+        path = path.resolve()
+        if path in seen:
+            return
+        seen.add(path)
+        with path.open("r", encoding="utf-8") as fh:
+            data = yaml.load(fh)
+        documents.append(data)
+        for d in _iter_dicts(data):
+            modules = d.get("modules")
+            if isinstance(modules, list):
+                for item in modules:
+                    if isinstance(item, str):
+                        load(path.parent / item)
+
+    load(root_path)
+    return documents
+
+
+def discover_pypi_names(root_path: Path) -> set[str]:
+    names = set()
+    for document in _load_forest(root_path):
+        for d in _iter_dicts(document):
+            checker = d.get("x-checker-data")
+            if isinstance(checker, dict) and checker.get("type") in ("pypi", "json"):
+                name = checker.get("name")
+                if name and not name.lower().startswith(PROTON_PREFIX):
+                    names.add(name)
+    return names
+
+
+def guess_fedora_package(pypi_name: str) -> str:
+    if pypi_name in FEDORA_NAME_OVERRIDES:
+        return FEDORA_NAME_OVERRIDES[pypi_name]
+    return f"python3-{canonicalize_name(pypi_name)}"
+
+
+def build_draft(root_path: Path, branch: str, session: requests.Session) -> dict:
+    mdapi = MdapiClient(branch, session=session)
+    modules: dict[str, dict] = {}
+
+    for pypi_name in sorted(discover_pypi_names(root_path)):
+        guess = guess_fedora_package(pypi_name)
+        entry = {"recipe": "pypi", "pypi_name": pypi_name, "fedora_package": guess}
+        try:
+            mdapi.get_version(guess)
+        except PackageNotFoundError:
+            entry["_needs_manual_fix"] = f"{guess} not found in Fedora {branch}"
+        modules[guess] = entry
+
+    for name, hint in NATIVE_MODULE_HINTS.items():
+        fedora_package = hint.get("fedora_package", name)
+        entry = {"recipe": hint["recipe"], "fedora_package": fedora_package}
+        entry.update({k: v for k, v in hint.items() if k not in ("recipe", "fedora_package")})
+        try:
+            version = mdapi.get_version(fedora_package)
+        except PackageNotFoundError:
+            entry["_needs_manual_fix"] = f"{fedora_package} not found in Fedora {branch}"
+            modules[name] = entry
+            continue
+
+        if hint["recipe"] == "archive":
+            rendered = Template(hint["url_template"]).substitute(version=version)
+            response = session.head(rendered, allow_redirects=True, timeout=30)
+            if response.status_code >= 400:
+                entry["_needs_manual_fix"] = (
+                    f"url_template renders to {rendered} which returned "
+                    f"{response.status_code} for version {version}"
+                )
+        modules[name] = entry
+
+    for module_name, note in MANUAL_FOLLOWUP.items():
+        modules.setdefault(module_name, {})["manual_followup"] = note
+
+    return {"modules": modules}
+
+
+@click.command()
+@click.option(
+    "--manifest",
+    type=click.Path(path_type=Path),
+    default=Path("com.protonvpn.www.yml"),
+    show_default=True,
+    help="Path to the root Flatpak manifest to walk.",
+)
+def main(manifest: Path) -> None:
+    """Print a draft .fedora-tracked-modules.yaml to stdout for review."""
+    session = requests.Session()
+    branch = get_current_stable_branch(session=session)
+    draft = build_draft(manifest, branch, session)
+
+    yaml = YAML()
+    yaml.default_flow_style = False
+    yaml.dump(draft, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Run the migration script from the repo root**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater python -m fedora_flatpak_updater.migrate --manifest com.protonvpn.www.yml > /tmp/fedora-tracked-modules.draft.yaml
+cat /tmp/fedora-tracked-modules.draft.yaml
+```
+
+Expected: a YAML document with a `modules:` map covering every discovered PyPI name (as `python3-<name>` keys) plus the 8 `NATIVE_MODULE_HINTS` entries. Entries MDAPI couldn't verify carry `_needs_manual_fix: "..."`.
+
+- [ ] **Step 3: Apply the known hand-fixes**
+
+Open `/tmp/fedora-tracked-modules.draft.yaml` and apply these changes (all confirmed live against real services per the design doc):
+
+1. Change the `python3-cryptography` entry's `recipe` from `pypi` to `pypi-multi-wheel` and add `wheel_arches: [aarch64, x86_64]`.
+2. Confirm `pycairo` → `python3-cairo` and `pygobject` → `python3-gobject` have no `_needs_manual_fix` (already handled by `FEDORA_NAME_OVERRIDES`).
+3. For every remaining entry still carrying `_needs_manual_fix`, resolve it by hand: query `https://mdapi.fedoraproject.org/<branch>/pkg/<candidate-name>` for plausible alternate spellings, or remove the module from the mapping entirely if it turns out to have no Fedora equivalent (it then simply stays untracked, keeping its current upstream-pinned behavior).
+4. Delete every remaining `_needs_manual_fix` key once resolved (they are debugging aids only, not part of the final schema `mapping_loader.py` expects).
+5. Double check no entry's `fedora_package` or `pypi_name` starts with `proton` (case-insensitive) — if one slipped through, delete that module entry.
+
+- [ ] **Step 4: Save the reviewed file as `.fedora-tracked-modules.yaml`**
+
+```bash
+cp /tmp/fedora-tracked-modules.draft.yaml .fedora-tracked-modules.yaml
+```
+
+- [ ] **Step 5: Validate the file loads cleanly**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater python -c "
+from pathlib import Path
+from fedora_flatpak_updater.mapping_loader import load_mapping
+specs = load_mapping(Path('.fedora-tracked-modules.yaml'))
+print(f'{len(specs)} modules loaded')
+assert not any(s.name.lower().startswith('proton') or (s.pypi_name or '').lower().startswith('proton') for s in specs)
+"
+```
+
+Expected: prints a module count (roughly 50-60) with no `AssertionError`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat: add migration helper and initial .fedora-tracked-modules.yaml"
+```
+
+---
+
+### Task 12: Run the updater for real and pin the manifests
+
+**Files:**
+- Modify: `com.protonvpn.www.yml`
+- Modify: `pip-resources.proton-vpn-cli.yaml`
+- Modify: `pip-resources.proton-vpn-gtk-app.yaml`
+- Modify: `pip-resources.python-proton-core.yaml`
+- Modify: `pip-resources.python-proton-keyring-linux.yaml`
+- Modify: `pip-resources.python-proton-vpn-api-core.yaml`
+
+**Interfaces:**
+- Consumes: `cli.main` (Task 10), `.fedora-tracked-modules.yaml` (Task 11)
+
+- [ ] **Step 1: Dry-run first and read the summary**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater python -m fedora_flatpak_updater.cli --dry-run
+```
+
+Expected: a GitHub-flavored markdown table with one row per tracked module, status `updated`/`unchanged`/`skipped`. Read every `skipped` reason before proceeding.
+
+- [ ] **Step 2: Run for real**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater python -m fedora_flatpak_updater.cli
+```
+
+Expected: same table, and this time `com.protonvpn.www.yml` plus the `pip-resources.*.yaml` files are modified on disk.
+
+- [ ] **Step 3: Review the diff**
+
+```bash
+git --no-pager diff --stat
+git --no-pager diff com.protonvpn.www.yml
+```
+
+Confirm: (a) only `url`/`sha256`/`tag`/`commit`/`x-checker-data` fields changed on tracked modules, (b) Proton-owned modules are untouched, (c) the `NetworkManager`/`NetworkManager-openvpn` `versions: <...>` ceilings and ALL other `x-checker-data` blocks on tracked sources are gone.
+
+- [ ] **Step 4: Sanity-check the manifest is still valid YAML**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater python -c "
+from ruamel.yaml import YAML
+yaml = YAML(typ='safe')
+for path in ['com.protonvpn.www.yml', 'pip-resources.proton-vpn-cli.yaml', 'pip-resources.proton-vpn-gtk-app.yaml', 'pip-resources.python-proton-core.yaml', 'pip-resources.python-proton-keyring-linux.yaml', 'pip-resources.python-proton-vpn-api-core.yaml']:
+    with open(path) as fh:
+        yaml.load(fh)
+    print(path, 'OK')
+"
+```
+
+Expected: `OK` for all six files.
+
+- [ ] **Step 5: If `python3-bcrypt` was updated, regenerate its Cargo sources**
+
+Check the CLI summary table for the `[manual follow-up: ...]` annotation on `python3-bcrypt`. If present, use `flatpak-builder-tools`' `cargo/flatpak-cargo-generator.py` against the new version's `Cargo.lock` to regenerate `bcrypt-cargo-sources.json` before merging. This is a manual follow-up outside the tool's scope (see design doc's Known Limitations) — flag it in the PR description rather than trying to automate it here.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "chore: pin Flatpak dependencies to Fedora-stable versions"
+```
+
+---
+
+### Task 13: GitHub Actions workflows (scheduled update + conditional tests) + final validation
+
+**Files:**
+- Create: `.github/workflows/update-fedora-flatpak-deps.yml`
+- Create: `.github/workflows/test-fedora-flatpak-updater.yml`
+
+**Interfaces:**
+- Consumes: `fedora_flatpak_updater.cli` (Task 10), `.fedora-tracked-modules.yaml` (Task 11), the test suite from Tasks 3-10
+
+- [ ] **Step 1: Create the scheduled update workflow file**
+
+```yaml
+# .github/workflows/update-fedora-flatpak-deps.yml
+name: Update Fedora-stable Flatpak dependencies
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # every Monday at 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+
+      - name: Sync fedora_flatpak_updater environment
+        run: uv sync --project scripts/fedora_flatpak_updater
+
+      - name: Run updater
+        run: |
+          uv run --project scripts/fedora_flatpak_updater python -m fedora_flatpak_updater.cli \
+            --mapping .fedora-tracked-modules.yaml \
+            --manifest com.protonvpn.www.yml | tee summary.md
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open pull request
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore: update Flatpak dependencies to Fedora-stable versions"
+          title: "chore: update Flatpak dependencies to Fedora-stable versions"
+          body-path: summary.md
+          branch: fedora-stable-flatpak-deps-update
+          delete-branch: true
+```
+
+- [ ] **Step 2: Create the conditional test workflow file**
+
+This workflow runs the unit test suite on every push/PR that touches the updater's own code or tests — separate from the scheduled workflow above, which actually calls out to Fedora/PyPI/git and opens a PR. It never makes real network calls; it only exercises the mocked test suite from Tasks 3-10.
+
+```yaml
+# .github/workflows/test-fedora-flatpak-updater.yml
+name: Test fedora_flatpak_updater
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "scripts/fedora_flatpak_updater/**"
+      - "tests/fedora_flatpak_updater/**"
+      - ".github/workflows/test-fedora-flatpak-updater.yml"
+  pull_request:
+    paths:
+      - "scripts/fedora_flatpak_updater/**"
+      - "tests/fedora_flatpak_updater/**"
+      - ".github/workflows/test-fedora-flatpak-updater.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+
+      - name: Sync fedora_flatpak_updater environment
+        run: uv sync --project scripts/fedora_flatpak_updater
+
+      - name: Run test suite
+        run: uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater -v
+```
+
+The `paths:` filters mean this job is skipped entirely on commits/PRs that don't touch `scripts/fedora_flatpak_updater/`, `tests/fedora_flatpak_updater/`, or the workflow file itself (e.g. changes to `com.protonvpn.www.yml` alone, or to unrelated parts of the repo, won't trigger it). If your repository requires this check to be "required" in branch protection, add it as a required status check named `test` under the `Test fedora_flatpak_updater` workflow — GitHub still reports skipped-due-to-path-filter runs as passing for that purpose.
+
+- [ ] **Step 3: Commit both workflow files**
+
+```bash
+git add -A
+git commit -m "ci: add scheduled Fedora-stable Flatpak dependency update workflow and conditional test run (uv)"
+```
+
+- [ ] **Step 4: Run the full test suite one final time locally**
+
+```bash
+uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater -v
+```
+
+Expected: every test from Tasks 3-10 passes (no network calls made — all HTTP interactions are mocked via `responses`, all `git` interactions via the injectable `runner` callable).
+
+- [ ] **Step 5: Confirm the old scratch work is fully gone and nothing references it**
+
+```bash
+git --no-pager log --oneline -1
+find . -iname "*fedora_pip_updater*" -o -iname "*.fedora-pip-mapping*" 2>/dev/null
+```
+
+Expected: no matches (aside from `.git` internals, if any).
+
+- [ ] **Step 6: Final review**
+
+```bash
+git --no-pager log --oneline -13
+git --no-pager diff --stat main...HEAD
+```
+
+Confirm the commit history matches the 13 tasks above and the diff touches exactly: the new `scripts/fedora_flatpak_updater/` package (including committed `uv.lock`), the new `tests/fedora_flatpak_updater/` suite, `.fedora-tracked-modules.yaml`, `.github/workflows/update-fedora-flatpak-deps.yml`, `.github/workflows/test-fedora-flatpak-updater.yml`, `.gitignore`, the six patched manifest files, and the deletions from Task 1.

--- a/docs/superpowers/specs/2026-07-01-fedora-stable-flatpak-deps-design.md
+++ b/docs/superpowers/specs/2026-07-01-fedora-stable-flatpak-deps-design.md
@@ -1,0 +1,159 @@
+# Fedora-Stable Flatpak Dependency Pinning — Design
+
+## Purpose
+
+Keep every third-party dependency in the ProtonVPN Flatpak manifest (`com.protonvpn.www.yml` and its nested `pip-resources.*.yaml` files) pinned to the exact version currently shipped in **Fedora's latest stable release**, instead of "whatever upstream's latest release is." A scheduled job resolves each tracked module's Fedora-stable version, reconstructs the matching upstream source (URL + checksum, or git tag + commit), patches the manifest files in place, and opens a PR.
+
+This replaces an earlier, incomplete, uncommitted attempt (`scripts/fedora_pip_updater/`, `.fedora-pip-mapping.yaml`, `tests/fedora_pip_updater/`, `docs/superpowers/plans/2026-05-29-fedora-pip-versions-workflow.md`) that was narrower in scope (PyPI packages only) and relied on Anitya (upstream release-monitoring data, not actual Fedora package versions). That scratch work should be deleted as part of implementation.
+
+## Scope
+
+**In scope — every module in `com.protonvpn.www.yml` (including everything pulled in transitively via `pip-resources.*.yaml`) that has a real Fedora package equivalent.** This includes:
+- Plain PyPI packages built with `buildsystem: simple` (e.g. `packaging`, `idna`, `cryptography`, `click`, `keyring`, `aiohttp`, `jaraco.classes`, ...) — roughly 50 modules across `com.protonvpn.www.yml` and the five `pip-resources.*.yaml` files.
+- Native/C-library modules built from source archives or git checkouts (`libndp`, `polkit`, `libnma`, `iproute2`, `dbus-python`).
+- Native modules with an existing "don't upgrade past X" ceiling in their `x-checker-data` (`NetworkManager` — `versions: < 1.42.0`; `NetworkManager-openvpn` — `versions: < 1.10.4`). **Decision: drop these ceilings.** Always take whatever version Fedora ships. If a patch (e.g. `patches/NetworkManager/disable-ownership-check-for-plugins.patch`) stops applying because of this, that surfaces as a normal Flatpak build failure in CI/PR review — it is not this tool's job to guess compatibility.
+
+**Out of scope — excluded entirely, keep current behavior untouched:**
+- Proton-owned modules, because they are not packaged in Fedora at all: `python-proton-core`, `python-proton-keyring-linux`, `python-proton-vpn-api-core`, `python-proton-vpn-local-agent` (the `.deb`-sourced binary agent from Proton's own Debian repo), `proton-vpn-cli`, `proton-vpn-gtk-app`.
+- `proton-vpn-local-agent` **PyPI wheel** (a separate, metadata-only artifact pulled into `pip-resources.python-proton-vpn-api-core.yaml`) — also a Proton package, also excluded, despite being PyPI-sourced. General rule: any package whose PyPI/Fedora name starts with `proton` is excluded regardless of which file it appears in.
+- `systemd`'s vendored `python3-pefile` stays in scope (it's a genuine third-party PyPI package, not Proton's).
+
+## Validated Technical Approach
+
+Before finalizing this design, the following were verified live against the real services (not assumed):
+
+1. **Determining "latest Fedora stable" automatically** — query Bodhi's `GET https://bodhi.fedoraproject.org/releases/?state=current`, filter to entries with `id_prefix == "FEDORA"` (excludes `FEDORA-CONTAINER`/`FEDORA-FLATPAK`/`FEDORA-EPEL*` variants) and a non-null `released_on` in the past, then pick the highest `version`. Confirmed this currently resolves to `f44` (Fedora 44), correctly preferring it over `f43` even though both report `state: current`. **No manual "bump the target Fedora version" step is ever needed.**
+
+2. **Resolving a package's Fedora-stable version** — query `GET https://mdapi.fedoraproject.org/<branch>/pkg/<fedora_package_name>`, read the `version` field. Confirmed against `NetworkManager` (1.54.3), `python3-cryptography` (46.0.7), `python3-idna` (3.11), `python3-gobject` (3.56.2), `libndp` (1.9), `polkit` (127), `python3-cairo` (1.28.0), `python3-gnupg` (0.5.4), `python3-jaraco-classes` (3.4.0), `python3-dbus-fast` (2.45.1). A 404 means the package isn't in that Fedora branch — treated as a skip, not a hard error.
+
+3. **Resolving a PyPI-backed source for a known version** — query `GET https://pypi.org/pypi/<name>/<version>/json` and read `urls[].digests.sha256` directly from the response. **We do not need to download the artifact and hash it ourselves** — PyPI already publishes the sha256 for every file. Confirmed with `idna==3.11`.
+
+4. **Resolving an archive-backed source for a known version** — render the module's known `url-template` (e.g. `https://github.com/jpirko/libndp/archive/v$version.tar.gz`) with the target version, then `HEAD` it to confirm it resolves before treating it as the new source (still needs a `GET`+sha256 for real use). **Confirmed this can go stale**: `polkit`'s current `url-template` (`https://gitlab.freedesktop.org/polkit/polkit/-/archive/$version/polkit-$version.tar.gz`) 404s for version `127`, because upstream polkit moved to `https://github.com/polkit-org/polkit`. The correct current URL (`https://github.com/polkit-org/polkit/archive/refs/tags/127.tar.gz`) was confirmed to resolve. **Consequence: the migration step that builds the tracked-module mapping must verify each `url_template` against the module's current Fedora version, not blindly copy the existing `x-checker-data.url-template` out of the manifest.**
+
+5. **Resolving a git-tag-backed source for a known version** — render the module's `tag_template` (e.g. `$version`) or match its `tag-pattern` (e.g. `^v([\d.]+)$`), then `git ls-remote --tags <repo_url>` and look for that tag. Confirmed against NetworkManager.git for tag `1.54.3`: it returns **two** lines, one for `refs/tags/1.54.3` (the tag object) and one for `refs/tags/1.54.3^{}` (the peeled/dereferenced commit). **The peeled hash is what must be used for the manifest's `commit:` field** — annotated tags point at a tag object, not a commit, and Flatpak needs the actual commit.
+
+6. **Guessing a Fedora package name from a PyPI name** — Fedora packages provide a normalized capability `python3dist(<name>)` following PEP 503 normalization (lowercase, `.`/`_` → `-`), and the binary RPM is conventionally `python3-<normalized-name>` (confirmed: `jaraco.classes` → `python3-jaraco-classes`, `python-gnupg` → `python3-gnupg`, `pycairo` → `python3-cairo` — note this one does *not* follow the naive `python3-<pypi-name>` pattern, so guesses still need verification). This convention is a useful **starting guess** when building the mapping file, but every guess must be confirmed to resolve via MDAPI before being committed — never trust the convention blindly.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    A[GitHub Actions: scheduled weekly + workflow_dispatch] --> B[Detect current Fedora stable branch via Bodhi API]
+    B --> C[Load .fedora-tracked-modules.yaml]
+    C --> D[Query MDAPI for each mapped module's Fedora version]
+    D --> E[Resolve new source per recipe kind]
+    E --> F[pypi / pypi-multi-wheel: PyPI JSON API, read digests.sha256]
+    E --> G[archive: render url_template, HEAD/GET, sha256]
+    E --> H[git: render tag_template or match tag_pattern, git ls-remote, use peeled commit]
+    F --> I[Patch manifest YAML in place with ruamel.yaml round-trip]
+    G --> I
+    H --> I
+    I --> J{git diff non-empty?}
+    J -->|yes| K[Open PR via peter-evans/create-pull-request, body = summary table]
+    J -->|no| L[Exit clean, no PR]
+```
+
+## Components
+
+### `.fedora-tracked-modules.yaml` (repo root)
+
+Single source of truth. Keyed by the exact Flatpak module `name` as it appears in the manifest tree. Each entry declares everything needed to reconstruct a source from a Fedora version string:
+
+```yaml
+modules:
+  python3-cryptography:
+    fedora_package: python3-cryptography
+    recipe: pypi-multi-wheel
+    pypi_name: cryptography
+    wheel_arches: [aarch64, x86_64]
+
+  python3-idna:
+    fedora_package: python3-idna
+    recipe: pypi
+    pypi_name: idna
+    prefer: wheel
+
+  libndp:
+    fedora_package: libndp
+    recipe: archive
+    url_template: "https://github.com/jpirko/libndp/archive/v$version.tar.gz"
+
+  polkit:
+    fedora_package: polkit
+    recipe: archive
+    url_template: "https://github.com/polkit-org/polkit/archive/refs/tags/$version.tar.gz"
+
+  NetworkManager:
+    fedora_package: NetworkManager
+    recipe: git
+    repo_url: "https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git"
+    tag_template: "$version"
+
+  systemd:
+    fedora_package: systemd
+    recipe: git
+    repo_url: "https://github.com/systemd/systemd.git"
+    tag_pattern: "^v([\\d.]+)$"
+```
+
+Recipe kinds:
+- `pypi` — single wheel or sdist, `prefer: wheel|sdist` picks which to use when both exist.
+- `pypi-multi-wheel` — the `cryptography` special case: multiple `only-arches`-scoped wheel sources in the manifest, one per arch, each needs its own URL+sha256 for the same resolved version.
+- `archive` — render `url_template`, fetch, compute sha256.
+- `git` — render `tag_template` (exact substitution) or find the first tag matching `tag_pattern`, resolve via `git ls-remote --tags`, use the peeled (`^{}`) hash when present, else the plain hash.
+
+Proton-owned modules (listed in Scope above) are **not present in this file at all** — the tool only ever acts on modules it finds an entry for.
+
+### `scripts/fedora_flatpak_updater/` (new, replaces the deleted scratch package)
+
+- `fedora_release.py` — calls Bodhi, returns the current stable branch string (e.g. `"f44"`).
+- `mdapi_client.py` — thin client for `mdapi.fedoraproject.org/<branch>/pkg/<name>`; per-run in-memory cache; raises a typed `PackageNotFoundError` on 404.
+- `recipes/pypi.py` — implements `pypi` and `pypi-multi-wheel`.
+- `recipes/archive.py` — implements `archive`.
+- `recipes/git.py` — implements `git`, including peeled-tag resolution.
+- `manifest_patcher.py` — `ruamel.yaml` (round-trip mode) based. Walks `com.protonvpn.www.yml` and all `pip-resources.*.yaml`, finds every source block belonging to a given module `name` (a module name may appear more than once in the tree, e.g. `python3-flit_core`), and mutates only `url`/`sha256`/`tag`/`commit` fields in place — comments, key order, and YAML anchors/aliases (used in `pip-resources.proton-vpn-gtk-app.yaml` and others) must be byte-identical elsewhere.
+- `cli.py` — orchestrates a full run. Flags: `--dry-run`, `--only <module-name>` (repeatable, for local debugging). Always prints a final summary table (updated / unchanged / skipped-with-reason).
+
+### Manifest changes
+
+For every module now covered by `.fedora-tracked-modules.yaml`, remove its `x-checker-data` block from the manifest source entry. `flatpak-external-data-checker` (Flathub's own bot) only checks sources that carry `x-checker-data`, so removing it stops that bot from fighting this tool's pinned versions. Proton-owned modules keep their existing `x-checker-data` untouched.
+
+### Workflow
+
+`.github/workflows/update-fedora-flatpak-deps.yml`:
+- Triggers: weekly `schedule` cron + `workflow_dispatch`.
+- Steps: checkout → set up Python → install deps → run `python -m fedora_flatpak_updater.cli` → if `git diff --quiet` reports changes, open a PR via `peter-evans/create-pull-request` with the run's summary table as the PR body; otherwise exit cleanly with no PR.
+
+## Error Handling
+
+- **Bodhi lookup fails** → hard fail, retry once, then exit non-zero with a clear message. Nothing else can proceed without a target branch.
+- **MDAPI 404** (package not in this Fedora branch) → skip module, record reason, continue.
+- **MDAPI 5xx** (transient) → retry once, then skip + record.
+- **Recipe resolution fails** (PyPI doesn't have that exact version; archive URL 404s; git tag not found upstream for that version string) → skip module, record the specific reason (e.g. `"tried tag 1.54.3 on NetworkManager.git, not found"`), continue.
+- **No modules changed** → CLI exits 0 with "nothing to update"; workflow skips PR creation.
+- Every run ends with a summary table (updated / unchanged / skipped-with-reason) that becomes the PR body, so a human can see at a glance what needs manual follow-up.
+
+## Testing Strategy
+
+All HTTP and `git` calls are mocked in unit tests — no real network access in the test suite.
+
+- `test_fedora_release.py` — mocked Bodhi JSON, verifies branch selection (filters container/flatpak/EPEL variants, excludes unreleased, picks highest version).
+- `test_mdapi_client.py` — mocked HTTP, verifies version extraction and 404/5xx handling.
+- `test_recipes_pypi.py` — mocked PyPI JSON, verifies wheel/sdist selection and the `cryptography` multi-arch case.
+- `test_recipes_archive.py` — mocked HTTP, verifies URL templating and sha256 computation.
+- `test_recipes_git.py` — mocked `git ls-remote` output, verifies tag-template rendering, tag-pattern matching, peeled-hash preference, and the not-found skip path.
+- `test_manifest_patcher.py` — real small fixture YAML files (including an anchor/alias pair and a duplicated module name), verified byte-for-byte identical except the intended fields, using `ruamel.yaml`.
+- `test_cli.py` — full orchestration with everything mocked: `--dry-run`, summary output, skip/failure aggregation.
+
+## Migration Plan (build the initial mapping file)
+
+1. Reuse a recursive manifest walker (similar to the discarded `inventory.py`) to enumerate every module in `com.protonvpn.www.yml` and all `pip-resources.*.yaml`, excluding Proton-owned modules per Scope.
+2. For PyPI-backed modules, guess `fedora_package` as `python3-<PEP503-normalized-name>`, then verify the guess resolves via MDAPI; hand-fix the ones that don't (e.g. `pycairo` → `python3-cairo`, `pygobject` → `python3-gobject`).
+3. For the ~10 native/archive/git modules, hand-write the recipe using the existing `x-checker-data` as a starting point, but verify each `url_template`/`tag_template` actually resolves for the module's *current* Fedora version before committing it (the `polkit` case shows why).
+4. Remove `x-checker-data` from every module now covered by the mapping file.
+5. Delete the old scratch work: `scripts/fedora_pip_updater/`, `.fedora-pip-mapping.yaml`, `tests/fedora_pip_updater/`, `docs/superpowers/plans/2026-05-29-fedora-pip-versions-workflow.md`.
+
+## Known Limitations (accepted, not solved by this design)
+
+- `python3-bcrypt` vendors Rust crate sources in `bcrypt-cargo-sources.json` (for offline Cargo builds). Bumping `bcrypt`'s version can change its Cargo dependency graph, which this tool does not regenerate. If `bcrypt`'s Fedora version changes, the PR will need a manual `flatpak-cargo-generator` run before it can build — call this out explicitly in that module's mapping entry (e.g. a `manual_followup` note) so the PR description flags it.
+- Dropping the `NetworkManager`/`NetworkManager-openvpn` version ceilings (per the accepted decision) means a build breakage from an incompatible jump is expected to be caught by normal CI, not preemptively guarded against here.

--- a/pip-resources.proton-vpn-cli.yaml
+++ b/pip-resources.proton-vpn-cli.yaml
@@ -2,42 +2,28 @@
 build-commands: []
 buildsystem: simple
 modules:
-  - name: python3-click
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "click" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
-        sha256: 482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2
-        x-checker-data:
-          name: click
-          packagetype: bdist_wheel
-          type: pypi
-  - name: python3-dbus-fast
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "dbus-fast" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/c2/26/a75b4f79c56bd1f24e4cf85399b28a1a607d1052b9e66aceb961d79a6d3f/dbus_fast-5.0.16.tar.gz
-        sha256: 24d0a86f32acb209a41806d20cf8a9207e4d46760e23c32479d1951d43739080
-        x-checker-data:
-          name: dbus_fast
-          type: pypi
-  - name: python3-tabulate
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "tabulate" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
-        sha256: f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3
-        x-checker-data:
-          name: tabulate
-          packagetype: bdist_wheel
-          type: pypi
+- name: python3-click
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "click" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
+    sha256: 981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6
+- name: python3-dbus-fast
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "dbus-fast" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/4d/45/43e2826069e8ed2cb3a3b83da72d39a0fe52ece2eca3cac8ff5e070bbfa4/dbus_fast-2.45.1.tar.gz
+    sha256: 486195c42c5f8fac77e9c55b575e2c85636cff7db45ebc7a19f680b3b4084314
+- name: python3-tabulate
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "tabulate" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
+    sha256: 024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f
 name: pip-resources.proton-vpn-cli

--- a/pip-resources.proton-vpn-gtk-app.yaml
+++ b/pip-resources.proton-vpn-gtk-app.yaml
@@ -2,30 +2,22 @@
 build-commands: []
 buildsystem: simple
 modules:
-  - name: python3-pygobject
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "pygobject" --no-build-isolation
-    sources:
-      - &id001
-        type: file
-        url: https://files.pythonhosted.org/packages/22/d9/1728840a22a4ef8a8f479b9156aa2943cd98c3907accd3849fb0d5f82bfd/pycairo-1.29.0.tar.gz
-        sha256: f3f7fde97325cae80224c09f12564ef58d0d0f655da0e3b040f5807bd5bd3142
-        x-checker-data:
-          name: pycairo
-          type: pypi
-      - type: file
-        url: https://files.pythonhosted.org/packages/da/61/978c5fbca34f10a90df362502fbb5a005637909e7b5a0e9212349ea9d010/pygobject-3.56.3.tar.gz
-        sha256: 12760e4a0e3d04b6eb95e06f7a27e362c826d567ea613373a92c003b6c70d2d6
-        x-checker-data:
-          name: pygobject
-          type: pypi
-  - name: python3-pycairo
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "pycairo" --no-build-isolation
-    sources:
-      - *id001
+- name: python3-pygobject
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "pygobject" --no-build-isolation
+  sources:
+  - &id001
+    type: file
+    url: https://files.pythonhosted.org/packages/40/d9/412da520de9052b7e80bfc810ec10f5cb3dbfa4aa3e23c2820dc61cdb3d0/pycairo-1.28.0.tar.gz
+    sha256: 26ec5c6126781eb167089a123919f87baa2740da2cca9098be8b3a6b91cc5fbc
+  - type: file
+    url: https://files.pythonhosted.org/packages/a2/80/09247a2be28af2c2240132a0af6c1005a2b1d089242b13a2cd782d2de8d7/pygobject-3.56.2.tar.gz
+    sha256: b816098969544081de9eecedb94ad6ac59c77e4d571fe7051f18bebcec074313
+- name: python3-pycairo
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "pycairo" --no-build-isolation
+  sources:
+  - *id001
 name: pip-resources.proton-vpn-gtk-app

--- a/pip-resources.python-proton-core.yaml
+++ b/pip-resources.python-proton-core.yaml
@@ -2,142 +2,83 @@
 build-commands: []
 buildsystem: simple
 modules:
-  - name: python3-expandvars
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "expandvars" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/7f/e6/79c43f7a55264e479a9fbf21ddba6a73530b3ea8439a8bb7fa5a281721af/expandvars-1.1.2-py3-none-any.whl
-        sha256: d1652fe4e61914f5b88ada93aaedb396446f55ae4621de45c8cb9f66e5712526
-        x-checker-data:
-          name: expandvars
-          packagetype: bdist_wheel
-          type: pypi
-  - name: python3-requests
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "requests" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl
-        sha256: 3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897
-        x-checker-data:
-          name: certifi
-          packagetype: bdist_wheel
-          type: pypi
-      - type: file
-        url: https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz
-        sha256: ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5
-        x-checker-data:
-          name: charset_normalizer
-          type: pypi
-      - &id001
-        type: file
-        url: https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl
-        sha256: 466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c
-        x-checker-data:
-          name: idna
-          packagetype: bdist_wheel
-          type: pypi
-      - type: file
-        url: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
-        sha256: 2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0
-        x-checker-data:
-          name: requests
-          packagetype: bdist_wheel
-          type: pypi
-      - type: file
-        url: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-        sha256: 9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
-        x-checker-data:
-          name: urllib3
-          packagetype: bdist_wheel
-          type: pypi
-  - name: python3-python-gnupg
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "python-gnupg" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/d2/ab/0ea9de971caf3cd2e268d2b05dfe9883b21cfe686a59249bd2dccb4bae33/python_gnupg-0.5.6-py2.py3-none-any.whl
-        sha256: b5050a55663d8ab9fcc8d97556d229af337a87a3ebebd7054cbd8b7e2043394a
-        x-checker-data:
-          name: python_gnupg
-          packagetype: bdist_wheel
-          type: pypi
-  - name: python3-aiohttp
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "aiohttp" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/5f/fc/a7bf5b6e4e617b45f90f2d9d2a68519c249c81dd4fc2658c7a2a61c4f4b7/aiohappyeyeballs-2.6.2-py3-none-any.whl
-        sha256: 4708045e2d7a6c6bdf8aafa8ed39649eaf926a4543b54560659129e3365953c4
-        x-checker-data:
-          name: aiohappyeyeballs
-          packagetype: bdist_wheel
-          type: pypi
-      - type: file
-        url: https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz
-        sha256: 9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1
-        x-checker-data:
-          name: aiohttp
-          type: pypi
-      - type: file
-        url: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
-        sha256: 053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e
-        x-checker-data:
-          name: aiosignal
-          packagetype: bdist_wheel
-          type: pypi
-      - type: file
-        url: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
-        sha256: c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309
-        x-checker-data:
-          name: attrs
-          packagetype: bdist_wheel
-          type: pypi
-      - type: file
-        url: https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz
-        sha256: 3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad
-        x-checker-data:
-          name: frozenlist
-          type: pypi
-      - *id001
-      - type: file
-        url: https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz
-        sha256: ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d
-        x-checker-data:
-          name: multidict
-          type: pypi
-      - type: file
-        url: https://files.pythonhosted.org/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz
-        sha256: 01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427
-        x-checker-data:
-          name: propcache
-          type: pypi
-      - type: file
-        url: https://files.pythonhosted.org/packages/79/12/1e8f37460ea0f7eb59c221fdaf0ed75e7ac43e97f8093b9c6f411df50a78/yarl-1.24.2.tar.gz
-        sha256: 9ac374123c6fd7abf64d1fec93962b0bd4ee2c19751755a762a72dd96c0378f8
-        x-checker-data:
-          name: yarl
-          type: pypi
-  - name: python3-pyxdg
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "pyxdg" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/e5/8d/cf41b66a8110670e3ad03dab9b759704eeed07fa96e90fdc0357b2ba70e2/pyxdg-0.28-py2.py3-none-any.whl
-        sha256: bdaf595999a0178ecea4052b7f4195569c1ff4d344567bccdc12dfdf02d545ab
-        x-checker-data:
-          name: pyxdg
-          packagetype: bdist_wheel
-          type: pypi
+- name: python3-expandvars
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "expandvars" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/7f/e6/79c43f7a55264e479a9fbf21ddba6a73530b3ea8439a8bb7fa5a281721af/expandvars-1.1.2-py3-none-any.whl
+    sha256: d1652fe4e61914f5b88ada93aaedb396446f55ae4621de45c8cb9f66e5712526
+- name: python3-requests
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "requests" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl
+    sha256: 9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c
+  - type: file
+    url: https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz
+    sha256: 94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a
+  - &id001
+    type: file
+    url: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
+    sha256: 771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea
+  - type: file
+    url: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
+    sha256: 2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6
+  - type: file
+    url: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+    sha256: 9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
+- name: python3-python-gnupg
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "python-gnupg" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/7b/5b/6666ed5a0d3ce4d5444af62e373d5ba8ab253a03487c86f2f9f1078e7c31/python_gnupg-0.5.4-py2.py3-none-any.whl
+    sha256: 40ce25cde9df29af91fe931ce9df3ce544e14a37f62b13ca878c897217b2de6c
+- name: python3-aiohttp
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "aiohttp" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/5f/fc/a7bf5b6e4e617b45f90f2d9d2a68519c249c81dd4fc2658c7a2a61c4f4b7/aiohappyeyeballs-2.6.2-py3-none-any.whl
+    sha256: 4708045e2d7a6c6bdf8aafa8ed39649eaf926a4543b54560659129e3365953c4
+    x-checker-data:
+      name: aiohappyeyeballs
+      packagetype: bdist_wheel
+      type: pypi
+  - type: file
+    url: https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz
+    sha256: 9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1
+  - type: file
+    url: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+    sha256: 053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e
+  - type: file
+    url: https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl
+    sha256: adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373
+  - type: file
+    url: https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz
+    sha256: 3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad
+  - *id001
+  - type: file
+    url: https://files.pythonhosted.org/packages/69/7f/0652e6ed47ab288e3756ea9c0df8b14950781184d4bd7883f4d87dd41245/multidict-6.6.4.tar.gz
+    sha256: d2d4e4787672911b48350df02ed3fa3fffdc2f2e8ca06dd6afdf34189b76a9dd
+  - type: file
+    url: https://files.pythonhosted.org/packages/9e/da/e9fc233cf63743258bff22b3dfa7ea5baef7b5bc324af47a0ad89b8ffc6f/propcache-0.4.1.tar.gz
+    sha256: f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d
+  - type: file
+    url: https://files.pythonhosted.org/packages/57/63/0c6ebca57330cd313f6102b16dd57ffaf3ec4c83403dcb45dbd15c6f3ea1/yarl-1.22.0.tar.gz
+    sha256: bebf8557577d4401ba8bd9ff33906f1376c877aa78d1fe216ad01b4d6745af71
+- name: python3-pyxdg
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "pyxdg" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/e5/8d/cf41b66a8110670e3ad03dab9b759704eeed07fa96e90fdc0357b2ba70e2/pyxdg-0.28-py2.py3-none-any.whl
+    sha256: bdaf595999a0178ecea4052b7f4195569c1ff4d344567bccdc12dfdf02d545ab
 name: pip-resources.python-proton-core

--- a/pip-resources.python-proton-keyring-linux.yaml
+++ b/pip-resources.python-proton-keyring-linux.yaml
@@ -2,74 +2,35 @@
 name: python3-keyring
 buildsystem: simple
 build-commands:
-  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-    --prefix=${FLATPAK_DEST} "keyring" --no-build-isolation
+- pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "keyring" --no-build-isolation
 sources:
-  - type: file
-    url: https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz
-    sha256: 44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529
-    x-checker-data:
-      name: cffi
-      type: pypi
-  - type: file
-    url: https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz
-    sha256: 5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920
-    x-checker-data:
-      name: cryptography
-      type: pypi
-  - type: file
-    url: https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl
-    sha256: f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790
-    x-checker-data:
-      name: jaraco.classes
-      packagetype: bdist_wheel
-      type: pypi
-  - type: file
-    url: https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl
-    sha256: bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535
-    x-checker-data:
-      name: jaraco.context
-      packagetype: bdist_wheel
-      type: pypi
-  - type: file
-    url: https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl
-    sha256: 79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4
-    x-checker-data:
-      name: jaraco_functools
-      packagetype: bdist_wheel
-      type: pypi
-  - type: file
-    url: https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl
-    sha256: 97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683
-    x-checker-data:
-      name: jeepney
-      packagetype: bdist_wheel
-      type: pypi
-  - type: file
-    url: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
-    sha256: be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f
-    x-checker-data:
-      name: keyring
-      packagetype: bdist_wheel
-      type: pypi
-  - type: file
-    url: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
-    sha256: 4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192
-    x-checker-data:
-      name: more_itertools
-      packagetype: bdist_wheel
-      type: pypi
-  - type: file
-    url: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
-    sha256: b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
-    x-checker-data:
-      name: pycparser
-      packagetype: bdist_wheel
-      type: pypi
-  - type: file
-    url: https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl
-    sha256: 0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137
-    x-checker-data:
-      name: secretstorage
-      packagetype: bdist_wheel
-      type: pypi
+- type: file
+  url: https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz
+  sha256: 44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529
+- type: file
+  url: https://files.pythonhosted.org/packages/a4/ba/04b1bd4218cbc58dc90ce967106d51582371b898690f3ae0402876cc4f34/cryptography-46.0.6.tar.gz
+  sha256: 27550628a518c5c6c903d84f637fbecf287f6cb9ced3804838a1295dc1fd0759
+- type: file
+  url: https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl
+  sha256: f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790
+- type: file
+  url: https://files.pythonhosted.org/packages/8d/48/aa685dbf1024c7bd82bede569e3a85f82c32fd3d79ba5fea578f0159571a/jaraco_context-6.1.0-py3-none-any.whl
+  sha256: a43b5ed85815223d0d3cfdb6d7ca0d2bc8946f28f30b6f3216bda070f68badda
+- type: file
+  url: https://files.pythonhosted.org/packages/b4/09/726f168acad366b11e420df31bf1c702a54d373a83f968d94141a8c3fde0/jaraco_functools-4.3.0-py3-none-any.whl
+  sha256: 227ff8ed6f7b8f62c56deff101545fa7543cf2c8e7b82a7c2116e672f29c26e8
+- type: file
+  url: https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl
+  sha256: 97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683
+- type: file
+  url: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
+  sha256: be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f
+- type: file
+  url: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
+  sha256: 52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b
+- type: file
+  url: https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl
+  sha256: c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc
+- type: file
+  url: https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl
+  sha256: 0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137

--- a/pip-resources.python-proton-vpn-api-core.yaml
+++ b/pip-resources.python-proton-vpn-api-core.yaml
@@ -2,105 +2,67 @@
 build-commands: []
 buildsystem: simple
 modules:
-  - name: python3-fido2
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "fido2" --no-build-isolation
-    sources:
-      - &id001
-        type: file
-        url: https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz
-        sha256: 44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529
-        x-checker-data:
-          name: cffi
-          type: pypi
-      - type: file
-        url: https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz
-        sha256: 5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920
-        x-checker-data:
-          name: cryptography
-          type: pypi
-      - type: file
-        url: https://files.pythonhosted.org/packages/01/82/f3c5dd87b0977f5547cc132b7969e6f5075a8c2f5881cf4b6df6378505f9/fido2-2.2.0-py3-none-any.whl
-        sha256: 3587ccf0af7b71b5dd73f17e1dbec9f0fd157292f9163f02e7778f46d0d25fe5
-        x-checker-data:
-          name: fido2
-          packagetype: bdist_wheel
-          type: pypi
-      - &id002
-        type: file
-        url: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
-        sha256: b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
-        x-checker-data:
-          name: pycparser
-          packagetype: bdist_wheel
-          type: pypi
-  - name: python3-distro
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "distro" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl
-        sha256: 7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
-        x-checker-data:
-          name: distro
-          packagetype: bdist_wheel
-          type: pypi
-  - name: python3-sentry-sdk
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "sentry-sdk" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl
-        sha256: 3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897
-        x-checker-data:
-          name: certifi
-          packagetype: bdist_wheel
-          type: pypi
-      - type: file
-        url: https://files.pythonhosted.org/packages/df/54/c9218db183846e08efaf68534889ef42e499dde432778881104a42f7071b/sentry_sdk-2.61.1-py3-none-any.whl
-        sha256: fa36eaf4b8ad708f718500d4bdcc1532637526a22beb874d88cbc0a46458b5ae
-        x-checker-data:
-          name: sentry_sdk
-          packagetype: bdist_wheel
-          type: pypi
-      - type: file
-        url: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-        sha256: 9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
-        x-checker-data:
-          name: urllib3
-          packagetype: bdist_wheel
-          type: pypi
-  - name: python3-PyNaCl
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "PyNaCl" --no-build-isolation
-    sources:
-      - *id001
-      - *id002
-      - type: file
-        url: https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz
-        sha256: 018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c
-        x-checker-data:
-          name: pynacl
-          type: pypi
-  - name: python3-proton-vpn-local-agent
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "proton-vpn-local-agent" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/86/56/e65acae43c2d54ad8b72d694a67e8f30b6f3f196a7ccf418f9e843875599/proton_vpn_local_agent-0.1.1-py3-none-any.whl
-        sha256: eb15cfbb115ea2a15d503e59f46e745709cca49bf115514443ffce5baffd2794
-        x-checker-data:
-          name: proton_vpn_local_agent
-          packagetype: bdist_wheel
-          type: pypi
+- name: python3-fido2
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "fido2" --no-build-isolation
+  sources:
+  - &id001
+    type: file
+    url: https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz
+    sha256: 44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529
+  - type: file
+    url: https://files.pythonhosted.org/packages/a4/ba/04b1bd4218cbc58dc90ce967106d51582371b898690f3ae0402876cc4f34/cryptography-46.0.6.tar.gz
+    sha256: 27550628a518c5c6c903d84f637fbecf287f6cb9ced3804838a1295dc1fd0759
+  - type: file
+    url: https://files.pythonhosted.org/packages/4c/7d/a1dba174d7ec4b6b8d6360eed0ac3a4a4e2aa45f234e903592d3184c6c3f/fido2-2.0.0-py3-none-any.whl
+    sha256: 685f54a50a57e019c6156e2dd699802a603e3abf70bab334f26affdd4fb8d4f7
+  - &id002
+    type: file
+    url: https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl
+    sha256: c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc
+- name: python3-distro
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "distro" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl
+    sha256: 7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
+- name: python3-sentry-sdk
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "sentry-sdk" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl
+    sha256: 9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c
+  - type: file
+    url: https://files.pythonhosted.org/packages/4d/19/8d77f9992e5cbfcaa9133c3bf63b4fbbb051248802e1e803fed5c552fbb2/sentry_sdk-2.48.0-py2.py3-none-any.whl
+    sha256: 6b12ac256769d41825d9b7518444e57fa35b5642df4c7c5e322af4d2c8721172
+  - type: file
+    url: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+    sha256: 9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
+- name: python3-PyNaCl
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "PyNaCl" --no-build-isolation
+  sources:
+  - *id001
+  - *id002
+  - type: file
+    url: https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz
+    sha256: 018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c
+- name: python3-proton-vpn-local-agent
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "proton-vpn-local-agent" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/86/56/e65acae43c2d54ad8b72d694a67e8f30b6f3f196a7ccf418f9e843875599/proton_vpn_local_agent-0.1.1-py3-none-any.whl
+    sha256: eb15cfbb115ea2a15d503e59f46e745709cca49bf115514443ffce5baffd2794
+    x-checker-data:
+      name: proton_vpn_local_agent
+      packagetype: bdist_wheel
+      type: pypi
 name: pip-resources.python-proton-vpn-api-core

--- a/pip-resources.python-skbuild.yaml
+++ b/pip-resources.python-skbuild.yaml
@@ -2,92 +2,61 @@
 build-commands: []
 buildsystem: simple
 modules:
-  - name: python3-hatchling
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "hatchling" --no-build-isolation
-    sources:
-      - &id001
-        type: file
-        url: https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl
-        sha256: 50af9343281f34785fab12da82e445ed987a6efb34fd8c2fc0f6e6630dbcc1b0
-        x-checker-data:
-          name: hatchling
-          packagetype: bdist_wheel
-          type: pypi
-      - &id002
-        type: file
-        url: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
-        sha256: a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189
-        x-checker-data:
-          name: pathspec
-          packagetype: bdist_wheel
-          type: pypi
-      - &id003
-        type: file
-        url: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-        sha256: e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
-        x-checker-data:
-          name: pluggy
-          packagetype: bdist_wheel
-          type: pypi
-      - &id004
-        type: file
-        url: https://files.pythonhosted.org/packages/c9/02/9a14d3048ffa4f45b7c60956a9b22688dd925d6de50f6baf7e55f3664942/trove_classifiers-2026.5.22.10-py3-none-any.whl
-        sha256: 01fe864225726e03efb843827ecabfe319fc4dee8dd66d65b8996cb09be46e2c
-        x-checker-data:
-          name: trove_classifiers
-          packagetype: bdist_wheel
-          type: pypi
-      - &id005
-        type: file
-        url: https://files.pythonhosted.org/packages/e6/60/73603fbcdbe5e803855bcce4414f94eaeed449083bd8183e67161af78188/vcs_versioning-1.1.1-py3-none-any.whl
-        sha256: b541e2ba79fc6aaa3850f8a7f88af43d97c1c80649c01142ee4146eddbc599e4
-        x-checker-data:
-          name: vcs-versioning
-          packagetype: bdist_wheel
-          type: pypi
-  - name: python3-hatch-fancy-pypi-readme
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "hatch-fancy-pypi-readme" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/58/b4/ad71e051b34f1935783de37beffee16e343ff2514b204dc515f9e939d4af/hatch_fancy_pypi_readme-25.1.0-py3-none-any.whl
-        sha256: ce0134c40d63d874ac48f48ccc678b8f3b62b8e50e9318520d2bffc752eedaf3
-        x-checker-data:
-          name: hatch_fancy_pypi_readme
-          packagetype: bdist_wheel
-          type: pypi
-      - *id001
-      - *id002
-      - *id003
-      - *id004
-  - name: python3-hatch-vcs
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "hatch-vcs" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/5f/48/1f85cee4b7b4f40b9b814b1febbc661bda6ced9649e410a0b74f6e415dd0/hatch_vcs-0.5.0-py3-none-any.whl
-        sha256: b49677dbdc597460cc22d01b27ab3696f5e16a21ecf2700fb01bc28e1f2a04a7
-        x-checker-data:
-          name: hatch_vcs
-          packagetype: bdist_wheel
-          type: pypi
-      - *id001
-      - *id002
-      - *id003
-      - type: file
-        url: https://files.pythonhosted.org/packages/5c/e1/342c4434df56aa537f6ce7647eefee521d96fbb828b08acd709865767652/setuptools_scm-10.0.5-py3-none-any.whl
-        sha256: f611037d8aae618221503b8fa89319f073438252ae3420e01c9ceec249131a0a
-        x-checker-data:
-          name: setuptools_scm
-          packagetype: bdist_wheel
-          type: pypi
-      - *id005
-      - *id004
+- name: python3-hatchling
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "hatchling" --no-build-isolation
+  sources:
+  - &id001
+    type: file
+    url: https://files.pythonhosted.org/packages/56/49/2797ec0ef88008a653a8867bb8d1e5c223cd2df8e40390dd5c6a0279cbc5/hatchling-1.30.1-py3-none-any.whl
+    sha256: 161eacafb3c6f91526e92116d21426369f2c36e98c36a864f11a96345ad4ee31
+  - &id002
+    type: file
+    url: https://files.pythonhosted.org/packages/32/2b/121e912bd60eebd623f873fd090de0e84f322972ab25a7f9044c056804ed/pathspec-1.0.3-py3-none-any.whl
+    sha256: e80767021c1cc524aa3fb14bedda9c34406591343cc42797b386ce7b9354fb6c
+  - &id003
+    type: file
+    url: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
+    sha256: e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
+  - &id004
+    type: file
+    url: https://files.pythonhosted.org/packages/bb/4a/2e5583e544bc437d5e8e54b47db87430df9031b29b48d17f26d129fa60c0/trove_classifiers-2026.1.14.14-py3-none-any.whl
+    sha256: 1f9553927f18d0513d8e5ff80ab8980b8202ce37ecae0e3274ed2ef11880e74d
+  - &id005
+    type: file
+    url: https://files.pythonhosted.org/packages/e6/60/73603fbcdbe5e803855bcce4414f94eaeed449083bd8183e67161af78188/vcs_versioning-1.1.1-py3-none-any.whl
+    sha256: b541e2ba79fc6aaa3850f8a7f88af43d97c1c80649c01142ee4146eddbc599e4
+    x-checker-data:
+      name: vcs-versioning
+      packagetype: bdist_wheel
+      type: pypi
+- name: python3-hatch-fancy-pypi-readme
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "hatch-fancy-pypi-readme" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/58/b4/ad71e051b34f1935783de37beffee16e343ff2514b204dc515f9e939d4af/hatch_fancy_pypi_readme-25.1.0-py3-none-any.whl
+    sha256: ce0134c40d63d874ac48f48ccc678b8f3b62b8e50e9318520d2bffc752eedaf3
+  - *id001
+  - *id002
+  - *id003
+  - *id004
+- name: python3-hatch-vcs
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "hatch-vcs" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/5f/48/1f85cee4b7b4f40b9b814b1febbc661bda6ced9649e410a0b74f6e415dd0/hatch_vcs-0.5.0-py3-none-any.whl
+    sha256: b49677dbdc597460cc22d01b27ab3696f5e16a21ecf2700fb01bc28e1f2a04a7
+  - *id001
+  - *id002
+  - *id003
+  - type: file
+    url: https://files.pythonhosted.org/packages/3d/ea/ac2bf868899d0d2e82ef72d350d97a846110c709bacf2d968431576ca915/setuptools_scm-9.2.2-py3-none-any.whl
+    sha256: 30e8f84d2ab1ba7cb0e653429b179395d0c33775d54807fc5f1dd6671801aef7
+  - *id005
+  - *id004
 name: pip-resources.python-skbuild

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts for the ProtonVPN Flatpak repo."""

--- a/scripts/fedora_flatpak_updater/README.md
+++ b/scripts/fedora_flatpak_updater/README.md
@@ -1,0 +1,31 @@
+# fedora_flatpak_updater
+
+Pins every third-party dependency in `com.protonvpn.www.yml` and its
+`pip-resources.*.yaml` files to the version shipped in Fedora's latest
+stable release. See `docs/superpowers/specs/2026-07-01-fedora-stable-flatpak-deps-design.md`
+for the full design.
+
+## Setup
+
+From the repository root:
+
+    uv sync --project scripts/fedora_flatpak_updater
+
+This creates `scripts/fedora_flatpak_updater/.venv` and installs runtime +
+dev dependencies from `uv.lock`.
+
+## Usage
+
+    uv run --project scripts/fedora_flatpak_updater python -m fedora_flatpak_updater.cli --dry-run
+    uv run --project scripts/fedora_flatpak_updater python -m fedora_flatpak_updater.cli --only python3-idna --only libndp
+
+## Rebuilding the mapping file from scratch
+
+    uv run --project scripts/fedora_flatpak_updater python -m fedora_flatpak_updater.migrate > /tmp/draft.yaml
+
+Review the draft, hand-fix anything flagged `_needs_manual_fix`, and merge
+it into `.fedora-tracked-modules.yaml`.
+
+## Running tests
+
+    uv run --project scripts/fedora_flatpak_updater pytest tests/fedora_flatpak_updater -v

--- a/scripts/fedora_flatpak_updater/pyproject.toml
+++ b/scripts/fedora_flatpak_updater/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "fedora-flatpak-updater"
+version = "0.1.0"
+description = "Pins third-party Flatpak manifest dependencies to Fedora-stable versions"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "requests>=2.32",
+    "ruamel.yaml>=0.18",
+    "tenacity>=9.0",
+    "click>=8.1",
+    "tabulate>=0.9",
+    "packaging>=24.0",
+]
+
+[project.scripts]
+fedora-flatpak-updater = "fedora_flatpak_updater.cli:main"
+fedora-flatpak-updater-migrate = "fedora_flatpak_updater.migrate:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "responses>=0.25",
+]

--- a/scripts/fedora_flatpak_updater/pyproject.toml
+++ b/scripts/fedora_flatpak_updater/pyproject.toml
@@ -5,12 +5,12 @@ description = "Pins third-party Flatpak manifest dependencies to Fedora-stable v
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "requests>=2.32",
-    "ruamel.yaml>=0.18",
-    "tenacity>=9.0",
-    "click>=8.1",
-    "tabulate>=0.9",
-    "packaging>=24.0",
+    "requests>=2.34.2",
+    "ruamel.yaml>=0.19.1",
+    "tenacity>=9.1.4",
+    "click>=8.4.2",
+    "tabulate>=0.10.0",
+    "packaging>=26.2",
 ]
 
 [project.scripts]
@@ -23,6 +23,6 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
-    "pytest>=8.0",
-    "responses>=0.25",
+    "pytest>=9.1.1",
+    "responses>=0.26.2",
 ]

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/__init__.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/__init__.py
@@ -1,0 +1,1 @@
+"""fedora_flatpak_updater package."""

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/__main__.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/__main__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/cli.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/cli.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import click
+import requests
+from tabulate import tabulate
+
+from .fedora_release import BodhiLookupError, get_current_stable_branch
+from .manifest_patcher import ManifestForest, apply_archive, apply_git, apply_pypi
+from .mapping_loader import load_mapping
+from .mdapi_client import MdapiClient, MdapiTransientError, PackageNotFoundError
+from .models import ModuleSpec, RecipeKind
+from .recipes import archive as archive_recipe
+from .recipes import git as git_recipe
+from .recipes import pypi as pypi_recipe
+from .recipes.archive import ArchiveResolutionError
+from .recipes.git import GitTagNotFoundError
+from .recipes.pypi import PypiVersionNotFoundError
+
+
+@dataclass
+class Row:
+    module_name: str
+    status: str  # "updated" | "unchanged" | "skipped"
+    detail: str
+
+
+def _infer_prefer(url: str, fallback: str) -> str:
+    if url.endswith(".whl"):
+        return "wheel"
+    if url.endswith((".tar.gz", ".tar.bz2", ".zip")):
+        return "sdist"
+    return fallback
+
+
+def _resolve_pypi_block(
+    block: dict,
+    spec: ModuleSpec,
+    fedora_version: str,
+    session: requests.Session,
+    multi_wheel_cache: dict,
+):
+    if spec.recipe == RecipeKind.PYPI_MULTI_WHEEL and block.get("only-arches"):
+        arch = block["only-arches"][0]
+        cache_key = (spec.pypi_name, fedora_version)
+        if cache_key not in multi_wheel_cache:
+            multi_wheel_cache[cache_key] = pypi_recipe.resolve_multi_wheel(
+                spec.pypi_name, fedora_version, spec.wheel_arches, session=session
+            )
+        return multi_wheel_cache[cache_key].get(arch)
+
+    prefer = _infer_prefer(block.get("url", ""), spec.prefer)
+    return pypi_recipe.resolve(spec.pypi_name, fedora_version, prefer=prefer, session=session)
+
+
+def run(
+    mapping_path: Path,
+    manifest_root: Path,
+    *,
+    dry_run: bool = False,
+    only: list[str] | None = None,
+) -> list[Row]:
+    with requests.Session() as session:
+        branch = get_current_stable_branch(session=session)
+        specs = load_mapping(mapping_path)
+        if only:
+            specs = [spec for spec in specs if spec.name in only]
+
+        forest = ManifestForest(manifest_root)
+        mdapi = MdapiClient(branch, session=session)
+        multi_wheel_cache: dict = {}
+        rows: list[Row] = []
+
+        for spec in specs:
+            try:
+                fedora_version = mdapi.get_version(spec.fedora_package)
+            except (PackageNotFoundError, MdapiTransientError) as exc:
+                rows.append(Row(spec.name, "skipped", str(exc)))
+                continue
+
+            try:
+                if spec.recipe in (RecipeKind.PYPI, RecipeKind.PYPI_MULTI_WHEEL):
+                    report = apply_pypi(
+                        forest,
+                        spec,
+                        lambda block: _resolve_pypi_block(block, spec, fedora_version, session, multi_wheel_cache),
+                    )
+                elif spec.recipe == RecipeKind.ARCHIVE:
+                    source = archive_recipe.resolve(spec.url_template, fedora_version, session=session)
+                    report = apply_archive(forest, spec, source)
+                elif spec.recipe == RecipeKind.GIT:
+                    source = git_recipe.resolve(
+                        repo_url=spec.repo_url,
+                        version=fedora_version,
+                        tag_template=spec.tag_template,
+                        tag_pattern=spec.tag_pattern,
+                    )
+                    report = apply_git(forest, spec, source)
+                else:  # pragma: no cover - RecipeKind is exhaustive
+                    rows.append(Row(spec.name, "skipped", f"unknown recipe {spec.recipe}"))
+                    continue
+            except (PypiVersionNotFoundError, ArchiveResolutionError, GitTagNotFoundError) as exc:
+                rows.append(Row(spec.name, "skipped", str(exc)))
+                continue
+
+            if report.blocks_touched == 0:
+                rows.append(Row(spec.name, "unchanged", f"no matching source blocks found for {fedora_version}"))
+            else:
+                detail = f"-> {fedora_version} ({report.blocks_touched} block(s))"
+                if spec.manual_followup:
+                    detail += f" [manual follow-up: {spec.manual_followup}]"
+                rows.append(Row(spec.name, "updated", detail))
+
+        if not dry_run and any(row.status == "updated" for row in rows):
+            forest.save()
+
+        return rows
+
+
+def format_summary(rows: list[Row]) -> str:
+    table = [[row.module_name, row.status, row.detail] for row in rows]
+    return tabulate(table, headers=["Module", "Status", "Detail"], tablefmt="github")
+
+
+@click.command()
+@click.option(
+    "--mapping",
+    type=click.Path(path_type=Path),
+    default=Path(".fedora-tracked-modules.yaml"),
+    show_default=True,
+    help="Path to the tracked-modules mapping file.",
+)
+@click.option(
+    "--manifest",
+    type=click.Path(path_type=Path),
+    default=Path("com.protonvpn.www.yml"),
+    show_default=True,
+    help="Path to the root Flatpak manifest.",
+)
+@click.option("--dry-run", is_flag=True, default=False, help="Resolve and report without writing files.")
+@click.option("--only", multiple=True, help="Limit to specific tracked module name(s). Repeatable.")
+def main(mapping: Path, manifest: Path, dry_run: bool, only: tuple[str, ...]) -> None:
+    """Pin Flatpak manifest dependencies to Fedora-stable versions."""
+    try:
+        rows = run(mapping, manifest, dry_run=dry_run, only=list(only) or None)
+    except BodhiLookupError as exc:
+        click.echo(f"ERROR: {exc}", err=True)
+        raise SystemExit(1)
+
+    click.echo(format_summary(rows))
+    if not any(row.status == "updated" for row in rows):
+        click.echo("\nNothing to update.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/cli.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/cli.py
@@ -5,11 +5,12 @@ from pathlib import Path
 
 import click
 import requests
+import subprocess
 from tabulate import tabulate
 
 from .fedora_release import BodhiLookupError, get_current_stable_branch
 from .manifest_patcher import ManifestForest, apply_archive, apply_git, apply_pypi
-from .mapping_loader import load_mapping
+from .mapping_loader import MappingError, load_mapping
 from .mdapi_client import MdapiClient, MdapiTransientError, PackageNotFoundError
 from .models import ModuleSpec, RecipeKind
 from .recipes import archive as archive_recipe
@@ -79,6 +80,9 @@ def run(
             except (PackageNotFoundError, MdapiTransientError) as exc:
                 rows.append(Row(spec.name, "skipped", str(exc)))
                 continue
+            except requests.RequestException as exc:
+                rows.append(Row(spec.name, "skipped", f"network error querying mdapi: {exc}"))
+                continue
 
             try:
                 if spec.recipe in (RecipeKind.PYPI, RecipeKind.PYPI_MULTI_WHEEL):
@@ -103,6 +107,12 @@ def run(
                     continue
             except (PypiVersionNotFoundError, ArchiveResolutionError, GitTagNotFoundError) as exc:
                 rows.append(Row(spec.name, "skipped", str(exc)))
+                continue
+            except requests.RequestException as exc:
+                rows.append(Row(spec.name, "skipped", f"network error resolving source: {exc}"))
+                continue
+            except subprocess.SubprocessError as exc:
+                rows.append(Row(spec.name, "skipped", f"subprocess error: {exc}"))
                 continue
 
             if report.blocks_touched == 0:
@@ -145,7 +155,7 @@ def main(mapping: Path, manifest: Path, dry_run: bool, only: tuple[str, ...]) ->
     """Pin Flatpak manifest dependencies to Fedora-stable versions."""
     try:
         rows = run(mapping, manifest, dry_run=dry_run, only=list(only) or None)
-    except BodhiLookupError as exc:
+    except (BodhiLookupError, MappingError) as exc:
         click.echo(f"ERROR: {exc}", err=True)
         raise SystemExit(1)
 

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/fedora_release.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/fedora_release.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import requests
+from tenacity import retry, retry_if_exception_type, stop_after_attempt
+
+BODHI_RELEASES_URL = "https://bodhi.fedoraproject.org/releases/"
+
+
+class BodhiLookupError(RuntimeError):
+    """Raised when the current Fedora stable branch cannot be determined."""
+
+
+@retry(
+    retry=retry_if_exception_type(requests.RequestException),
+    stop=stop_after_attempt(2),  # 1 try + 1 retry
+    reraise=True,
+)
+def _fetch_releases(session: requests.Session) -> dict:
+    response = session.get(BODHI_RELEASES_URL, params={"state": "current"}, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+
+def get_current_stable_branch(session: requests.Session | None = None) -> str:
+    """Returns the current Fedora stable branch, e.g. "f44".
+
+    Queries Bodhi for releases with state=current, keeps only entries whose
+    id_prefix is exactly "FEDORA" (excluding *-CONTAINER/*-FLATPAK/*-EPEL*
+    variants) and that have already been released (`released_on` is set),
+    then returns the highest `version` among those.
+    """
+    session = session or requests.Session()
+    try:
+        payload = _fetch_releases(session)
+    except requests.RequestException as exc:
+        raise BodhiLookupError(f"Bodhi releases lookup failed: {exc}") from exc
+
+    candidates = [
+        release
+        for release in payload.get("releases", [])
+        if release.get("id_prefix") == "FEDORA"
+        and release.get("released_on")
+        and release.get("version") is not None
+    ]
+    if not candidates:
+        raise BodhiLookupError("No current, released Fedora releases found in Bodhi response")
+
+    newest = max(candidates, key=lambda release: int(release["version"]))
+    return f"f{newest['version']}"

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/manifest_patcher.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/manifest_patcher.py
@@ -16,7 +16,12 @@ def _matches_pypi_name(url: str, pypi_name: str) -> bool:
         canonical + "-",
         canonical.replace("-", "_") + "-",  # wheel filenames use underscores
     }
-    return any(filename.startswith(prefix) for prefix in prefixes)
+    for prefix in prefixes:
+        if filename.startswith(prefix):
+            remainder = filename[len(prefix):]
+            if remainder and remainder[0].isdigit():
+                return True
+    return False
 
 
 def _iter_dicts(node: Any, seen: set[int] | None = None):

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/manifest_patcher.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/manifest_patcher.py
@@ -43,7 +43,7 @@ def _remove_checker_data(block: dict) -> None:
     ca = getattr(block, "ca", None)
     x_ca_items = ca.items.pop("x-checker-data", None) if ca and hasattr(ca, "items") else None
     x_data = block.pop("x-checker-data")
-    if not isinstance(block, dict) or not block:
+    if not block:
         return
 
     trailing_tokens = []
@@ -51,7 +51,7 @@ def _remove_checker_data(block: dict) -> None:
         for idx in (2, 3):
             if len(x_ca_items) > idx and x_ca_items[idx] is not None:
                 trailing_tokens.append(x_ca_items[idx])
-    if isinstance(x_data, dict) and hasattr(x_data, "ca"):
+    if isinstance(x_data, dict) and getattr(x_data, "ca", None):
         if x_data.ca.comment is not None:
             trailing_tokens.append(x_data.ca.comment)
         if x_data:
@@ -71,8 +71,8 @@ def _remove_checker_data(block: dict) -> None:
             items_list.append(None)
         if items_list[2] is None:
             items_list[2] = trailing_tokens[0]
-        else:
-            items_list[2] = trailing_tokens[0]
+        elif hasattr(items_list[2], "value") and hasattr(trailing_tokens[0], "value"):
+            items_list[2].value += trailing_tokens[0].value
 
 
 @dataclass

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/manifest_patcher.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/manifest_patcher.py
@@ -104,6 +104,7 @@ class ManifestForest:
     def __init__(self, root_path: Path):
         self._yaml = YAML(typ="rt")
         self._yaml.preserve_quotes = True
+        self._yaml.indent(mapping=2, sequence=4, offset=2)
         self._yaml.width = 1_000_000  # never re-wrap lines we didn't touch
         self.root_path = Path(root_path).resolve()
         self.documents: dict[Path, Any] = {}

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/manifest_patcher.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/manifest_patcher.py
@@ -62,17 +62,31 @@ def _remove_checker_data(block: dict) -> None:
                     if len(last_items) > idx and last_items[idx] is not None:
                         trailing_tokens.append(last_items[idx])
 
-    if trailing_tokens and ca and hasattr(ca, "items"):
+    flat_tokens = []
+    def _flatten(obj):
+        if obj is None:
+            return
+        if isinstance(obj, (list, tuple)):
+            for item in obj:
+                _flatten(item)
+        elif hasattr(obj, "value"):
+            flat_tokens.append(obj)
+
+    for t in trailing_tokens:
+        _flatten(t)
+
+    if flat_tokens and ca and hasattr(ca, "items"):
         new_last_k = list(block.keys())[-1]
         if new_last_k not in ca.items:
             ca.items[new_last_k] = [None, None, None, None]
         items_list = ca.items[new_last_k]
         while len(items_list) < 4:
             items_list.append(None)
-        if items_list[2] is None:
-            items_list[2] = trailing_tokens[0]
-        elif hasattr(items_list[2], "value") and hasattr(trailing_tokens[0], "value"):
-            items_list[2].value += trailing_tokens[0].value
+        for token in flat_tokens:
+            if items_list[2] is None:
+                items_list[2] = token
+            elif hasattr(items_list[2], "value") and hasattr(token, "value"):
+                items_list[2].value += token.value
 
 
 @dataclass
@@ -128,6 +142,8 @@ class ManifestForest:
     def save(self) -> list[Path]:
         written = []
         for path, data in self.documents.items():
+            if "shared-modules" in path.parts:
+                continue
             with path.open("w", encoding="utf-8") as fh:
                 self._yaml.dump(data, fh)
             written.append(path)

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/manifest_patcher.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/manifest_patcher.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from packaging.utils import canonicalize_name
+from ruamel.yaml import YAML
+
+
+def _matches_pypi_name(url: str, pypi_name: str) -> bool:
+    filename = url.rsplit("/", 1)[-1].lower()
+    canonical = str(canonicalize_name(pypi_name))  # PEP 503, e.g. "jaraco-classes"
+    prefixes = {
+        pypi_name.lower() + "-",
+        canonical + "-",
+        canonical.replace("-", "_") + "-",  # wheel filenames use underscores
+    }
+    return any(filename.startswith(prefix) for prefix in prefixes)
+
+
+def _iter_dicts(node: Any, seen: set[int] | None = None):
+    if seen is None:
+        seen = set()
+    if isinstance(node, dict):
+        if id(node) in seen:
+            return
+        seen.add(id(node))
+        yield node
+        for value in node.values():
+            yield from _iter_dicts(value, seen)
+    elif isinstance(node, list):
+        if id(node) in seen:
+            return
+        seen.add(id(node))
+        for item in node:
+            yield from _iter_dicts(item, seen)
+
+
+def _remove_checker_data(block: dict) -> None:
+    if "x-checker-data" not in block:
+        return
+    ca = getattr(block, "ca", None)
+    x_ca_items = ca.items.pop("x-checker-data", None) if ca and hasattr(ca, "items") else None
+    x_data = block.pop("x-checker-data")
+    if not isinstance(block, dict) or not block:
+        return
+
+    trailing_tokens = []
+    if x_ca_items:
+        for idx in (2, 3):
+            if len(x_ca_items) > idx and x_ca_items[idx] is not None:
+                trailing_tokens.append(x_ca_items[idx])
+    if isinstance(x_data, dict) and hasattr(x_data, "ca"):
+        if x_data.ca.comment is not None:
+            trailing_tokens.append(x_data.ca.comment)
+        if x_data:
+            last_k = list(x_data.keys())[-1]
+            if hasattr(x_data.ca, "items") and last_k in x_data.ca.items:
+                last_items = x_data.ca.items[last_k]
+                for idx in (2, 3):
+                    if len(last_items) > idx and last_items[idx] is not None:
+                        trailing_tokens.append(last_items[idx])
+
+    if trailing_tokens and ca and hasattr(ca, "items"):
+        new_last_k = list(block.keys())[-1]
+        if new_last_k not in ca.items:
+            ca.items[new_last_k] = [None, None, None, None]
+        items_list = ca.items[new_last_k]
+        while len(items_list) < 4:
+            items_list.append(None)
+        if items_list[2] is None:
+            items_list[2] = trailing_tokens[0]
+        else:
+            items_list[2] = trailing_tokens[0]
+
+
+@dataclass
+class PatchReport:
+    module_name: str
+    blocks_touched: int
+    files_touched: tuple[str, ...] = ()
+
+
+class ManifestForest:
+    """Loads the root manifest and every pip-resources.*.yaml it
+    (transitively) references as separate ruamel round-trip documents, keyed
+    by resolved Path, so each file can be re-serialized independently."""
+
+    def __init__(self, root_path: Path):
+        self._yaml = YAML(typ="rt")
+        self._yaml.preserve_quotes = True
+        self._yaml.width = 1_000_000  # never re-wrap lines we didn't touch
+        self.root_path = Path(root_path).resolve()
+        self.documents: dict[Path, Any] = {}
+        self._load(self.root_path)
+
+    def _load(self, path: Path) -> None:
+        if path in self.documents:
+            return
+        with path.open("r", encoding="utf-8") as fh:
+            data = self._yaml.load(fh)
+        self.documents[path] = data
+        self._discover_refs(data, path.parent)
+
+    def _discover_refs(self, node: Any, base_dir: Path) -> None:
+        if isinstance(node, dict):
+            modules = node.get("modules")
+            if isinstance(modules, list):
+                for item in modules:
+                    if isinstance(item, str):
+                        self._load((base_dir / item).resolve())
+                    elif isinstance(item, dict):
+                        self._discover_refs(item, base_dir)
+            for key, value in node.items():
+                if key == "modules":
+                    continue
+                self._discover_refs(value, base_dir)
+        elif isinstance(node, list):
+            for item in node:
+                self._discover_refs(item, base_dir)
+
+    def iter_dicts(self):
+        seen = set()
+        for data in self.documents.values():
+            yield from _iter_dicts(data, seen)
+
+    def save(self) -> list[Path]:
+        written = []
+        for path, data in self.documents.items():
+            with path.open("w", encoding="utf-8") as fh:
+                self._yaml.dump(data, fh)
+            written.append(path)
+        return written
+
+
+def find_module_blocks(forest: ManifestForest, module_name: str) -> list[dict]:
+    """archive/git recipes: match standalone flatpak modules by `name:`."""
+    return [d for d in forest.iter_dicts() if d.get("name") == module_name and "sources" in d]
+
+
+def find_pypi_source_blocks(forest: ManifestForest, pypi_name: str) -> list[dict]:
+    """pypi/pypi-multi-wheel recipes: match source dicts by URL filename
+    prefix, since the same PyPI package routinely appears bundled inside
+    many differently-named carrier modules across the manifest forest."""
+    return [
+        d
+        for d in forest.iter_dicts()
+        if d.get("type") in ("file", "archive")
+        and isinstance(d.get("url"), str)
+        and _matches_pypi_name(d["url"], pypi_name)
+    ]
+
+
+def apply_pypi(forest: ManifestForest, spec, resolve_block: Callable[[dict], Any]) -> PatchReport:
+    """`resolve_block(current_block)` is called once per matched block so
+    each occurrence can be resolved according to its own existing shape
+    (wheel vs sdist, arch-specific vs generic)."""
+    blocks = find_pypi_source_blocks(forest, spec.pypi_name)
+    touched = 0
+    for block in blocks:
+        source = resolve_block(block)
+        if source is None:
+            continue
+        block["url"] = source.url
+        block["sha256"] = source.sha256
+        _remove_checker_data(block)
+        touched += 1
+    return PatchReport(module_name=spec.name, blocks_touched=touched)
+
+
+def apply_archive(forest: ManifestForest, spec, source) -> PatchReport:
+    touched = 0
+    for module_block in find_module_blocks(forest, spec.name):
+        for src in module_block.get("sources", []):
+            if isinstance(src, dict) and src.get("type") == "archive":
+                src["url"] = source.url
+                src["sha256"] = source.sha256
+                _remove_checker_data(src)
+                touched += 1
+    return PatchReport(module_name=spec.name, blocks_touched=touched)
+
+
+def apply_git(forest: ManifestForest, spec, source) -> PatchReport:
+    touched = 0
+    for module_block in find_module_blocks(forest, spec.name):
+        for src in module_block.get("sources", []):
+            if isinstance(src, dict) and src.get("type") == "git":
+                src["tag"] = source.tag
+                src["commit"] = source.commit
+                _remove_checker_data(src)
+                touched += 1
+    return PatchReport(module_name=spec.name, blocks_touched=touched)

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/mapping_loader.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/mapping_loader.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+from .models import ModuleSpec, RecipeKind
+
+_yaml = YAML(typ="safe")
+
+
+class MappingError(ValueError):
+    """Raised when .fedora-tracked-modules.yaml is malformed."""
+
+
+def load_mapping(path: Path) -> list[ModuleSpec]:
+    with Path(path).open("r", encoding="utf-8") as fh:
+        raw = _yaml.load(fh) or {}
+
+    modules = raw.get("modules") or {}
+    specs: list[ModuleSpec] = []
+    for name, entry in modules.items():
+        if not isinstance(entry, dict):
+            raise MappingError(f"{name}: entry must be a mapping")
+        try:
+            recipe = RecipeKind(entry["recipe"])
+        except (KeyError, ValueError) as exc:
+            raise MappingError(f"{name}: invalid or missing 'recipe'") from exc
+        if "fedora_package" not in entry:
+            raise MappingError(f"{name}: missing 'fedora_package'")
+
+        specs.append(
+            ModuleSpec(
+                name=name,
+                fedora_package=entry["fedora_package"],
+                recipe=recipe,
+                pypi_name=entry.get("pypi_name"),
+                prefer=entry.get("prefer", "wheel"),
+                wheel_arches=tuple(entry.get("wheel_arches", ())),
+                url_template=entry.get("url_template"),
+                repo_url=entry.get("repo_url"),
+                tag_template=entry.get("tag_template"),
+                tag_pattern=entry.get("tag_pattern"),
+                manual_followup=entry.get("manual_followup"),
+            )
+        )
+    return specs

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/mdapi_client.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/mdapi_client.py
@@ -51,6 +51,6 @@ class MdapiClient:
             response = self.session.get(url, timeout=30)
         except requests.RequestException as exc:
             raise MdapiTransientError(f"{url} request failed: {exc}") from exc
-        if response.status_code >= 500:
+        if response.status_code >= 500 or response.status_code == 429:
             raise MdapiTransientError(f"{url} returned {response.status_code}")
         return response

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/mdapi_client.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/mdapi_client.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import requests
+from tenacity import retry, retry_if_exception_type, stop_after_attempt
+
+MDAPI_BASE = "https://mdapi.fedoraproject.org"
+
+
+class PackageNotFoundError(Exception):
+    def __init__(self, package_name: str, branch: str):
+        super().__init__(f"{package_name} not found in Fedora {branch}")
+        self.package_name = package_name
+        self.branch = branch
+
+
+class MdapiTransientError(RuntimeError):
+    """Raised when MDAPI returns a server error even after one retry."""
+
+
+class MdapiClient:
+    """Thin client for mdapi.fedoraproject.org/<branch>/pkg/<name>, with a
+    per-instance in-memory cache."""
+
+    def __init__(self, branch: str, session: requests.Session | None = None):
+        self.branch = branch
+        self.session = session or requests.Session()
+        self._cache: dict[str, str] = {}
+
+    def get_version(self, package_name: str) -> str:
+        if package_name in self._cache:
+            return self._cache[package_name]
+
+        url = f"{MDAPI_BASE}/{self.branch}/pkg/{package_name}"
+        response = self._get_with_retry(url)
+
+        if response.status_code == 404:
+            raise PackageNotFoundError(package_name, self.branch)
+        response.raise_for_status()
+
+        version = response.json()["version"]
+        self._cache[package_name] = version
+        return version
+
+    @retry(
+        retry=retry_if_exception_type(MdapiTransientError),
+        stop=stop_after_attempt(2),  # 1 try + 1 retry
+        reraise=True,
+    )
+    def _get_with_retry(self, url: str) -> requests.Response:
+        response = self.session.get(url, timeout=30)
+        if response.status_code >= 500:
+            raise MdapiTransientError(f"{url} returned {response.status_code}")
+        return response

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/mdapi_client.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/mdapi_client.py
@@ -33,7 +33,7 @@ class MdapiClient:
         url = f"{MDAPI_BASE}/{self.branch}/pkg/{package_name}"
         response = self._get_with_retry(url)
 
-        if response.status_code == 404:
+        if response.status_code in (400, 404):
             raise PackageNotFoundError(package_name, self.branch)
         response.raise_for_status()
 
@@ -47,7 +47,10 @@ class MdapiClient:
         reraise=True,
     )
     def _get_with_retry(self, url: str) -> requests.Response:
-        response = self.session.get(url, timeout=30)
+        try:
+            response = self.session.get(url, timeout=30)
+        except requests.RequestException as exc:
+            raise MdapiTransientError(f"{url} request failed: {exc}") from exc
         if response.status_code >= 500:
             raise MdapiTransientError(f"{url} returned {response.status_code}")
         return response

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/mdapi_client.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/mdapi_client.py
@@ -37,7 +37,10 @@ class MdapiClient:
             raise PackageNotFoundError(package_name, self.branch)
         response.raise_for_status()
 
-        version = response.json()["version"]
+        try:
+            version = response.json()["version"]
+        except (ValueError, KeyError) as exc:
+            raise MdapiTransientError(f"Invalid JSON response from MDAPI: {exc}") from exc
         self._cache[package_name] = version
         return version
 

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/migrate.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/migrate.py
@@ -1,0 +1,201 @@
+# scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/migrate.py
+"""One-off helper for building the initial .fedora-tracked-modules.yaml.
+
+Walks the manifest forest, collects every distinct third-party PyPI
+`x-checker-data.name` value plus the known native archive/git modules,
+guesses a Fedora package name for each, and verifies the guess against
+MDAPI (including a HEAD check for archive url_templates, since the design
+doc's `polkit` case shows a stale template resolving to a 404). Prints a
+YAML draft to stdout; a human reviews it, hand-fixes anything flagged
+`_needs_manual_fix`, and saves the result to .fedora-tracked-modules.yaml.
+
+Not part of the ongoing scheduled job — run manually only when rebuilding
+the mapping from scratch (e.g. after adding a new dependency).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from string import Template
+from typing import Any
+
+import click
+import requests
+from packaging.utils import canonicalize_name
+from ruamel.yaml import YAML
+
+from .fedora_release import get_current_stable_branch
+from .mdapi_client import MdapiClient, PackageNotFoundError
+
+PROTON_PREFIX = "proton"
+
+NATIVE_MODULE_HINTS: dict[str, dict] = {
+    "libndp": {
+        "recipe": "archive",
+        "url_template": "https://github.com/jpirko/libndp/archive/v$version.tar.gz",
+    },
+    "polkit": {
+        "recipe": "archive",
+        "url_template": "https://github.com/polkit-org/polkit/archive/refs/tags/$version.tar.gz",
+    },
+    "libnma": {
+        "recipe": "archive",
+        "url_template": "https://gitlab.gnome.org/GNOME/libnma/-/archive/$version/libnma-$version.tar.gz",
+    },
+    "iproute2": {
+        "recipe": "archive",
+        "url_template": "https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-$version.tar.xz",
+    },
+    "python-dbus": {
+        "recipe": "archive",
+        "fedora_package": "dbus-python",
+        "url_template": "https://dbus.freedesktop.org/releases/dbus-python/dbus-python-$version.tar.gz",
+    },
+    "NetworkManager": {
+        "recipe": "git",
+        "repo_url": "https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git",
+        "tag_template": "$version",
+    },
+    "NetworkManager-openvpn": {
+        "recipe": "git",
+        "repo_url": "https://github.com/NetworkManager/NetworkManager-openvpn.git",
+        "tag_template": "$version",
+    },
+    "systemd": {
+        "recipe": "git",
+        "repo_url": "https://github.com/systemd/systemd.git",
+        "tag_pattern": r"^v([\d.]+)$",
+    },
+}
+
+MANUAL_FOLLOWUP = {
+    "python3-bcrypt": (
+        "bcrypt vendors Rust crate sources in bcrypt-cargo-sources.json. "
+        "Re-run flatpak-cargo-generator against the new version's Cargo.lock "
+        "before merging."
+    ),
+}
+
+# Known guess-convention exceptions (design doc item 6).
+FEDORA_NAME_OVERRIDES = {
+    "pycairo": "python3-cairo",
+    "pygobject": "python3-gobject",
+}
+
+
+def _iter_dicts(node: Any):
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _iter_dicts(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_dicts(item)
+
+
+def _load_forest(root_path: Path) -> list[Any]:
+    yaml = YAML(typ="safe")
+    documents = []
+    seen: set[Path] = set()
+
+    def load(path: Path) -> None:
+        path = path.resolve()
+        if path in seen:
+            return
+        seen.add(path)
+        with path.open("r", encoding="utf-8") as fh:
+            data = yaml.load(fh)
+        documents.append(data)
+        for d in _iter_dicts(data):
+            modules = d.get("modules")
+            if isinstance(modules, list):
+                for item in modules:
+                    if isinstance(item, str):
+                        load(path.parent / item)
+
+    load(root_path)
+    return documents
+
+
+def discover_pypi_names(root_path: Path) -> set[str]:
+    names = set()
+    for document in _load_forest(root_path):
+        for d in _iter_dicts(document):
+            checker = d.get("x-checker-data")
+            if isinstance(checker, dict) and checker.get("type") in ("pypi", "json"):
+                name = checker.get("name")
+                if name and not name.lower().startswith(PROTON_PREFIX):
+                    names.add(name)
+    return names
+
+
+def guess_fedora_package(pypi_name: str) -> str:
+    if pypi_name in FEDORA_NAME_OVERRIDES:
+        return FEDORA_NAME_OVERRIDES[pypi_name]
+    return f"python3-{canonicalize_name(pypi_name)}"
+
+
+def build_draft(root_path: Path, branch: str, session: requests.Session) -> dict:
+    mdapi = MdapiClient(branch, session=session)
+    modules: dict[str, dict] = {}
+
+    for pypi_name in sorted(discover_pypi_names(root_path)):
+        guess = guess_fedora_package(pypi_name)
+        entry = {"recipe": "pypi", "pypi_name": pypi_name, "fedora_package": guess}
+        try:
+            mdapi.get_version(guess)
+        except Exception as exc:
+            entry["_needs_manual_fix"] = f"{guess} lookup failed in Fedora {branch}: {exc}"
+        modules[guess] = entry
+
+    for name, hint in NATIVE_MODULE_HINTS.items():
+        fedora_package = hint.get("fedora_package", name)
+        entry = {"recipe": hint["recipe"], "fedora_package": fedora_package}
+        entry.update({k: v for k, v in hint.items() if k not in ("recipe", "fedora_package")})
+        try:
+            version = mdapi.get_version(fedora_package)
+        except Exception as exc:
+            entry["_needs_manual_fix"] = f"{fedora_package} lookup failed in Fedora {branch}: {exc}"
+            modules[name] = entry
+            continue
+
+        if hint["recipe"] == "archive":
+            rendered = Template(hint["url_template"]).substitute(version=version)
+            try:
+                response = session.head(rendered, allow_redirects=True, timeout=30)
+                if response.status_code >= 400:
+                    entry["_needs_manual_fix"] = (
+                        f"url_template renders to {rendered} which returned "
+                        f"{response.status_code} for version {version}"
+                    )
+            except Exception as exc:
+                entry["_needs_manual_fix"] = f"url_template check failed for {rendered}: {exc}"
+        modules[name] = entry
+
+    for module_name, note in MANUAL_FOLLOWUP.items():
+        modules.setdefault(module_name, {})["manual_followup"] = note
+
+    return {"modules": modules}
+
+
+@click.command()
+@click.option(
+    "--manifest",
+    type=click.Path(path_type=Path),
+    default=Path("com.protonvpn.www.yml"),
+    show_default=True,
+    help="Path to the root Flatpak manifest to walk.",
+)
+def main(manifest: Path) -> None:
+    """Print a draft .fedora-tracked-modules.yaml to stdout for review."""
+    session = requests.Session()
+    branch = get_current_stable_branch(session=session)
+    draft = build_draft(manifest, branch, session)
+
+    yaml = YAML()
+    yaml.default_flow_style = False
+    yaml.dump(draft, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/migrate.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/migrate.py
@@ -25,7 +25,7 @@ from packaging.utils import canonicalize_name
 from ruamel.yaml import YAML
 
 from .fedora_release import get_current_stable_branch
-from .mdapi_client import MdapiClient, PackageNotFoundError
+from .mdapi_client import MdapiClient, MdapiTransientError, PackageNotFoundError
 
 PROTON_PREFIX = "proton"
 
@@ -144,7 +144,7 @@ def build_draft(root_path: Path, branch: str, session: requests.Session) -> dict
         entry = {"recipe": "pypi", "pypi_name": pypi_name, "fedora_package": guess}
         try:
             mdapi.get_version(guess)
-        except Exception as exc:
+        except (PackageNotFoundError, MdapiTransientError, requests.RequestException) as exc:
             entry["_needs_manual_fix"] = f"{guess} lookup failed in Fedora {branch}: {exc}"
         modules[guess] = entry
 
@@ -154,7 +154,7 @@ def build_draft(root_path: Path, branch: str, session: requests.Session) -> dict
         entry.update({k: v for k, v in hint.items() if k not in ("recipe", "fedora_package")})
         try:
             version = mdapi.get_version(fedora_package)
-        except Exception as exc:
+        except (PackageNotFoundError, MdapiTransientError, requests.RequestException) as exc:
             entry["_needs_manual_fix"] = f"{fedora_package} lookup failed in Fedora {branch}: {exc}"
             modules[name] = entry
             continue
@@ -168,7 +168,7 @@ def build_draft(root_path: Path, branch: str, session: requests.Session) -> dict
                         f"url_template renders to {rendered} which returned "
                         f"{response.status_code} for version {version}"
                     )
-            except Exception as exc:
+            except requests.RequestException as exc:
                 entry["_needs_manual_fix"] = f"url_template check failed for {rendered}: {exc}"
         modules[name] = entry
 

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/models.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/models.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class RecipeKind(str, Enum):
+    PYPI = "pypi"
+    PYPI_MULTI_WHEEL = "pypi-multi-wheel"
+    ARCHIVE = "archive"
+    GIT = "git"
+
+
+@dataclass(frozen=True)
+class ModuleSpec:
+    """One entry from .fedora-tracked-modules.yaml."""
+
+    name: str
+    fedora_package: str
+    recipe: RecipeKind
+    pypi_name: str | None = None
+    prefer: str = "wheel"
+    wheel_arches: tuple[str, ...] = ()
+    url_template: str | None = None
+    repo_url: str | None = None
+    tag_template: str | None = None
+    tag_pattern: str | None = None
+    manual_followup: str | None = None

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/__init__.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/__init__.py
@@ -1,0 +1,1 @@
+"""recipes package."""

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/archive.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/archive.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from string import Template
+
+import requests
+
+
+class ArchiveResolutionError(RuntimeError):
+    """Raised when a rendered archive URL cannot be fetched."""
+
+
+@dataclass(frozen=True)
+class ArchiveSource:
+    url: str
+    sha256: str
+
+
+def render_url(url_template: str, version: str) -> str:
+    return Template(url_template).substitute(version=version)
+
+
+def resolve(url_template: str, version: str, session: requests.Session | None = None) -> ArchiveSource:
+    own_session = session is None
+    if session is None:
+        session = requests.Session()
+    try:
+        url = render_url(url_template, version)
+        response = session.get(url, timeout=60, stream=True)
+        if response.status_code == 404:
+            raise ArchiveResolutionError(f"{url} returned 404")
+        response.raise_for_status()
+
+        digest = hashlib.sha256()
+        for chunk in response.iter_content(chunk_size=65536):
+            digest.update(chunk)
+        return ArchiveSource(url=url, sha256=digest.hexdigest())
+    finally:
+        if own_session:
+            session.close()

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/archive.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/archive.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import time
 from dataclasses import dataclass
 from string import Template
 
@@ -27,15 +28,24 @@ def resolve(url_template: str, version: str, session: requests.Session | None = 
         session = requests.Session()
     try:
         url = render_url(url_template, version)
-        response = session.get(url, timeout=60, stream=True)
-        if response.status_code == 404:
-            raise ArchiveResolutionError(f"{url} returned 404")
-        response.raise_for_status()
+        for attempt in range(3):
+            response = None
+            try:
+                response = session.get(url, timeout=60, stream=True)
+                if response.status_code == 404:
+                    raise ArchiveResolutionError(f"{url} returned 404")
+                response.raise_for_status()
 
-        digest = hashlib.sha256()
-        for chunk in response.iter_content(chunk_size=65536):
-            digest.update(chunk)
-        return ArchiveSource(url=url, sha256=digest.hexdigest())
+                digest = hashlib.sha256()
+                for chunk in response.iter_content(chunk_size=65536):
+                    digest.update(chunk)
+                return ArchiveSource(url=url, sha256=digest.hexdigest())
+            except (requests.RequestException, ArchiveResolutionError) as exc:
+                if response is not None:
+                    response.close()
+                if isinstance(exc, ArchiveResolutionError) or attempt == 2:
+                    raise
+                time.sleep(2 * (attempt + 1))
     finally:
         if own_session:
             session.close()

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/archive.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/archive.py
@@ -29,23 +29,21 @@ def resolve(url_template: str, version: str, session: requests.Session | None = 
     try:
         url = render_url(url_template, version)
         for attempt in range(3):
-            response = None
             try:
-                response = session.get(url, timeout=60, stream=True)
-                if response.status_code == 404:
-                    raise ArchiveResolutionError(f"{url} returned 404")
-                response.raise_for_status()
+                with session.get(url, timeout=60, stream=True) as response:
+                    if response.status_code == 404:
+                        raise ArchiveResolutionError(f"{url} returned 404")
+                    response.raise_for_status()
 
-                digest = hashlib.sha256()
-                for chunk in response.iter_content(chunk_size=65536):
-                    digest.update(chunk)
-                return ArchiveSource(url=url, sha256=digest.hexdigest())
+                    digest = hashlib.sha256()
+                    for chunk in response.iter_content(chunk_size=65536):
+                        digest.update(chunk)
+                    return ArchiveSource(url=url, sha256=digest.hexdigest())
             except (requests.RequestException, ArchiveResolutionError) as exc:
-                if response is not None:
-                    response.close()
                 if isinstance(exc, ArchiveResolutionError) or attempt == 2:
                     raise
                 time.sleep(2 * (attempt + 1))
     finally:
         if own_session:
             session.close()
+

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/git.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/git.py
@@ -74,9 +74,14 @@ def resolve(
         target_tag = None
         for tag_name in by_tag:
             match = pattern.match(tag_name)
-            if match and match.group(1) == version:
-                target_tag = tag_name
-                break
+            if match:
+                try:
+                    captured = match.group(1)
+                except IndexError:
+                    captured = match.group(0)
+                if captured == version:
+                    target_tag = tag_name
+                    break
         if target_tag is None:
             raise GitTagNotFoundError(
                 f"no tag matching {tag_pattern!r} for version {version} on {repo_url}"

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/git.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/git.py
@@ -25,7 +25,7 @@ def _ls_remote_tags(repo_url: str, runner) -> list[tuple[str, str]]:
                 capture_output=True,
                 text=True,
                 check=True,
-                timeout=120,
+                timeout=30,
             )
             break
         except (subprocess.TimeoutExpired, subprocess.CalledProcessError):
@@ -36,9 +36,12 @@ def _ls_remote_tags(repo_url: str, runner) -> list[tuple[str, str]]:
     for line in result.stdout.splitlines():
         if not line.strip():
             continue
+        if "\t" not in line:
+            continue
         sha, ref = line.split("\t", 1)
         entries.append((sha, ref.strip()))
     return entries
+
 
 
 def resolve(

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/git.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/git.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from string import Template
+
+
+class GitTagNotFoundError(RuntimeError):
+    """Raised when the target tag cannot be found on the remote."""
+
+
+@dataclass(frozen=True)
+class GitSource:
+    tag: str
+    commit: str
+
+
+def _ls_remote_tags(repo_url: str, runner) -> list[tuple[str, str]]:
+    result = runner(
+        ["git", "ls-remote", "--tags", repo_url],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    entries = []
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        sha, ref = line.split("\t", 1)
+        entries.append((sha, ref.strip()))
+    return entries
+
+
+def resolve(
+    *,
+    repo_url: str,
+    version: str,
+    tag_template: str | None = None,
+    tag_pattern: str | None = None,
+    runner=subprocess.run,
+) -> GitSource:
+    if not tag_template and not tag_pattern:
+        raise ValueError("Either tag_template or tag_pattern must be provided")
+
+    entries = _ls_remote_tags(repo_url, runner)
+
+    by_tag: dict[str, dict[str, str]] = {}
+    for sha, ref in entries:
+        if not ref.startswith("refs/tags/"):
+            continue
+        peeled = ref.endswith("^{}")
+        tag_name = ref[len("refs/tags/") :]
+        if peeled:
+            tag_name = tag_name[: -len("^{}")]
+        by_tag.setdefault(tag_name, {})["peeled" if peeled else "plain"] = sha
+
+    if tag_template:
+        target_tag = Template(tag_template).substitute(version=version)
+    else:
+        pattern = re.compile(tag_pattern)
+        target_tag = None
+        for tag_name in by_tag:
+            match = pattern.match(tag_name)
+            if match and match.group(1) == version:
+                target_tag = tag_name
+                break
+        if target_tag is None:
+            raise GitTagNotFoundError(
+                f"no tag matching {tag_pattern!r} for version {version} on {repo_url}"
+            )
+
+    hashes = by_tag.get(target_tag)
+    if not hashes:
+        raise GitTagNotFoundError(f"tried tag {target_tag!r} on {repo_url}, not found")
+
+    commit = hashes.get("peeled") or hashes.get("plain")
+    return GitSource(tag=target_tag, commit=commit)

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/git.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/git.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import subprocess
+import time
 from dataclasses import dataclass
 from string import Template
 
@@ -17,13 +18,20 @@ class GitSource:
 
 
 def _ls_remote_tags(repo_url: str, runner) -> list[tuple[str, str]]:
-    result = runner(
-        ["git", "ls-remote", "--tags", repo_url],
-        capture_output=True,
-        text=True,
-        check=True,
-        timeout=30,
-    )
+    for attempt in range(3):
+        try:
+            result = runner(
+                ["git", "ls-remote", "--tags", repo_url],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=120,
+            )
+            break
+        except (subprocess.TimeoutExpired, subprocess.CalledProcessError):
+            if attempt == 2:
+                raise
+            time.sleep(2 * (attempt + 1))
     entries = []
     for line in result.stdout.splitlines():
         if not line.strip():

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/pypi.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/pypi.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import requests
+
+PYPI_BASE = "https://pypi.org/pypi"
+
+
+class PypiVersionNotFoundError(RuntimeError):
+    """Raised when a specific pypi_name==version has no usable distribution."""
+
+
+@dataclass(frozen=True)
+class PypiSource:
+    url: str
+    sha256: str
+    only_arches: tuple[str, ...] = ()
+
+
+def fetch_release_files(pypi_name: str, version: str, session: requests.Session | None = None) -> list[dict]:
+    own_session = session is None
+    if session is None:
+        session = requests.Session()
+    try:
+        url = f"{PYPI_BASE}/{pypi_name}/{version}/json"
+        response = session.get(url, timeout=30)
+        if response.status_code == 404:
+            raise PypiVersionNotFoundError(f"{pypi_name}=={version} not found on PyPI")
+        response.raise_for_status()
+        return response.json()["urls"]
+    finally:
+        if own_session:
+            session.close()
+
+
+def resolve_wheel(pypi_name: str, version: str, session: requests.Session | None = None) -> PypiSource:
+    for file_info in fetch_release_files(pypi_name, version, session):
+        if file_info["packagetype"] == "bdist_wheel":
+            return PypiSource(url=file_info["url"], sha256=file_info["digests"]["sha256"])
+    raise PypiVersionNotFoundError(f"No wheel for {pypi_name}=={version}")
+
+
+def resolve_sdist(pypi_name: str, version: str, session: requests.Session | None = None) -> PypiSource:
+    for file_info in fetch_release_files(pypi_name, version, session):
+        if file_info["packagetype"] == "sdist":
+            return PypiSource(url=file_info["url"], sha256=file_info["digests"]["sha256"])
+    raise PypiVersionNotFoundError(f"No sdist for {pypi_name}=={version}")
+
+
+def resolve(
+    pypi_name: str,
+    version: str,
+    *,
+    prefer: str = "wheel",
+    session: requests.Session | None = None,
+) -> PypiSource:
+    primary, fallback = (resolve_wheel, resolve_sdist) if prefer == "wheel" else (resolve_sdist, resolve_wheel)
+    try:
+        return primary(pypi_name, version, session)
+    except PypiVersionNotFoundError:
+        return fallback(pypi_name, version, session)
+
+
+def resolve_multi_wheel(
+    pypi_name: str,
+    version: str,
+    wheel_arches: tuple[str, ...],
+    session: requests.Session | None = None,
+) -> dict[str, PypiSource]:
+    """The `cryptography` case: one manylinux wheel per architecture."""
+    files = fetch_release_files(pypi_name, version, session)
+    result: dict[str, PypiSource] = {}
+    for arch in wheel_arches:
+        for file_info in files:
+            if file_info["packagetype"] != "bdist_wheel":
+                continue
+            filename = file_info["filename"]
+            if arch in filename and "manylinux" in filename:
+                result[arch] = PypiSource(
+                    url=file_info["url"],
+                    sha256=file_info["digests"]["sha256"],
+                    only_arches=(arch,),
+                )
+                break
+        else:
+            raise PypiVersionNotFoundError(f"No wheel for {pypi_name}=={version} arch={arch}")
+    return result

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/pypi.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/recipes/pypi.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 
 import requests
@@ -24,11 +25,17 @@ def fetch_release_files(pypi_name: str, version: str, session: requests.Session 
         session = requests.Session()
     try:
         url = f"{PYPI_BASE}/{pypi_name}/{version}/json"
-        response = session.get(url, timeout=30)
-        if response.status_code == 404:
-            raise PypiVersionNotFoundError(f"{pypi_name}=={version} not found on PyPI")
-        response.raise_for_status()
-        return response.json()["urls"]
+        for attempt in range(3):
+            try:
+                response = session.get(url, timeout=60)
+                if response.status_code == 404:
+                    raise PypiVersionNotFoundError(f"{pypi_name}=={version} not found on PyPI")
+                response.raise_for_status()
+                return response.json()["urls"]
+            except (requests.RequestException, PypiVersionNotFoundError) as exc:
+                if isinstance(exc, PypiVersionNotFoundError) or attempt == 2:
+                    raise
+                time.sleep(2 * (attempt + 1))
     finally:
         if own_session:
             session.close()

--- a/scripts/fedora_flatpak_updater/uv.lock
+++ b/scripts/fedora_flatpak_updater/uv.lock
@@ -1,0 +1,440 @@
+version = 1
+revision = 2
+requires-python = ">=3.10"
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d", size = 315182, upload-time = "2026-04-02T09:25:40.673Z" },
+    { url = "https://files.pythonhosted.org/packages/24/47/b192933e94b546f1b1fe4df9cc1f84fcdbf2359f8d1081d46dd029b50207/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8", size = 209329, upload-time = "2026-04-02T09:25:42.354Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b4/01fa81c5ca6141024d89a8fc15968002b71da7f825dd14113207113fabbd/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790", size = 231230, upload-time = "2026-04-02T09:25:44.281Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/7b991776844dfa058017e600e6e55ff01984a063290ca5622c0b63162f68/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc", size = 225890, upload-time = "2026-04-02T09:25:45.475Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e7/bed0024a0f4ab0c8a9c64d4445f39b30c99bd1acd228291959e3de664247/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393", size = 216930, upload-time = "2026-04-02T09:25:46.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ab/b18f0ab31cdd7b3ddb8bb76c4a414aeb8160c9810fdf1bc62f269a539d87/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153", size = 202109, upload-time = "2026-04-02T09:25:48.031Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e5/7e9440768a06dfb3075936490cb82dbf0ee20a133bf0dd8551fa096914ec/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af", size = 214684, upload-time = "2026-04-02T09:25:49.245Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/8c61d8da9f062fdf457c80acfa25060ec22bf1d34bbeaca4350f13bcfd07/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34", size = 212785, upload-time = "2026-04-02T09:25:50.671Z" },
+    { url = "https://files.pythonhosted.org/packages/66/cd/6e9889c648e72c0ab2e5967528bb83508f354d706637bc7097190c874e13/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1", size = 203055, upload-time = "2026-04-02T09:25:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2e/7a951d6a08aefb7eb8e1b54cdfb580b1365afdd9dd484dc4bee9e5d8f258/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752", size = 232502, upload-time = "2026-04-02T09:25:53.388Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d5/abcf2d83bf8e0a1286df55cd0dc1d49af0da4282aa77e986df343e7de124/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53", size = 214295, upload-time = "2026-04-02T09:25:54.765Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3a/7d4cd7ed54be99973a0dc176032cba5cb1f258082c31fa6df35cff46acfc/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616", size = 227145, upload-time = "2026-04-02T09:25:55.904Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/98/3a45bf8247889cf28262ebd3d0872edff11565b2a1e3064ccb132db3fbb0/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a", size = 218884, upload-time = "2026-04-02T09:25:57.074Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/2e8b7f8915ed5c9ef13aa828d82738e33888c485b65ebf744d615040c7ea/charset_normalizer-3.4.7-cp310-cp310-win32.whl", hash = "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374", size = 148343, upload-time = "2026-04-02T09:25:58.199Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1b/3b8c8c77184af465ee9ad88b5aea46ea6b2e1f7b9dc9502891e37af21e30/charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943", size = 159174, upload-time = "2026-04-02T09:25:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/feb40dca40dbb21e0a908801782d9288c64fc8d8e562c2098e9994c8c21b/charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008", size = 147805, upload-time = "2026-04-02T09:26:00.756Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fedora-flatpak-updater"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "click" },
+    { name = "packaging" },
+    { name = "requests" },
+    { name = "ruamel-yaml" },
+    { name = "tabulate" },
+    { name = "tenacity" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "responses" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "click", specifier = ">=8.1" },
+    { name = "packaging", specifier = ">=24.0" },
+    { name = "requests", specifier = ">=2.32" },
+    { name = "ruamel-yaml", specifier = ">=0.18" },
+    { name = "tabulate", specifier = ">=0.9" },
+    { name = "tenacity", specifier = ">=9.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "responses", specifier = ">=0.25" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "responses"
+version = "0.26.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/58/1fb6de3503428196df78638f991ec8095274f1ee9723e272ee4d9ff0092b/responses-0.26.1.tar.gz", hash = "sha256:2eb3218553cc8f79b57d257bac23af5e1bf381f5b9390b1767816f0843e01dc2", size = 83088, upload-time = "2026-05-21T19:56:39.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/31/6a620b4427d546b9e7cca8b3b8c5f0559d9cef2bb9eedcda7f73c1473c19/responses-0.26.1-py3-none-any.whl", hash = "sha256:8aacc4586eb08fb2208ef64a9eb4258d9b0c6e6f4260845f2f018ab847495345", size = 35502, upload-time = "2026-05-21T19:56:38.046Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]

--- a/scripts/fedora_flatpak_updater/uv.lock
+++ b/scripts/fedora_flatpak_updater/uv.lock
@@ -170,18 +170,18 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=8.1" },
-    { name = "packaging", specifier = ">=24.0" },
-    { name = "requests", specifier = ">=2.32" },
-    { name = "ruamel-yaml", specifier = ">=0.18" },
-    { name = "tabulate", specifier = ">=0.9" },
-    { name = "tenacity", specifier = ">=9.0" },
+    { name = "click", specifier = ">=8.4.2" },
+    { name = "packaging", specifier = ">=26.2" },
+    { name = "requests", specifier = ">=2.34.2" },
+    { name = "ruamel-yaml", specifier = ">=0.19.1" },
+    { name = "tabulate", specifier = ">=0.10.0" },
+    { name = "tenacity", specifier = ">=9.1.4" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pytest", specifier = ">=8.0" },
-    { name = "responses", specifier = ">=0.25" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "responses", specifier = ">=0.26.2" },
 ]
 
 [[package]]
@@ -328,16 +328,16 @@ wheels = [
 
 [[package]]
 name = "responses"
-version = "0.26.1"
+version = "0.26.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/58/1fb6de3503428196df78638f991ec8095274f1ee9723e272ee4d9ff0092b/responses-0.26.1.tar.gz", hash = "sha256:2eb3218553cc8f79b57d257bac23af5e1bf381f5b9390b1767816f0843e01dc2", size = 83088, upload-time = "2026-05-21T19:56:39.747Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/1a/4af3e6d659394b809838490b144e4ab8d7ed3b9fecc7ca78f5d2f79b1a3d/responses-0.26.2.tar.gz", hash = "sha256:9c9259b46a8349197edebf43cfa68a87e1a2802ef503ff8b2fecbabc0b45afd8", size = 84030, upload-time = "2026-07-03T16:44:50.325Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/31/6a620b4427d546b9e7cca8b3b8c5f0559d9cef2bb9eedcda7f73c1473c19/responses-0.26.1-py3-none-any.whl", hash = "sha256:8aacc4586eb08fb2208ef64a9eb4258d9b0c6e6f4260845f2f018ab847495345", size = 35502, upload-time = "2026-05-21T19:56:38.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/28/693e1d9ebf72baa062ded80d837a035b86ce75eda5a269379e9e2b1008a8/responses-0.26.2-py3-none-any.whl", hash = "sha256:6fdfeabd58e5ec473b98dfe02e6d46d3173bd8dd573eff2ccccf1a05a5135364", size = 35609, upload-time = "2026-07-03T16:44:49.1Z" },
 ]
 
 [[package]]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the repo."""

--- a/tests/fedora_flatpak_updater/__init__.py
+++ b/tests/fedora_flatpak_updater/__init__.py
@@ -1,0 +1,1 @@
+"""tests for fedora_flatpak_updater."""

--- a/tests/fedora_flatpak_updater/fixtures/pip-resources.example.yaml
+++ b/tests/fedora_flatpak_updater/fixtures/pip-resources.example.yaml
@@ -1,0 +1,47 @@
+name: pip-resources.example
+build-commands: []
+buildsystem: simple
+modules:
+  - name: python3-requests
+    buildsystem: simple
+    build-commands:
+      - pip3 install requests
+    sources:
+      - &idna_anchor
+        type: file
+        url: https://files.pythonhosted.org/packages/94/16/idna-3.16-py3-none-any.whl
+        sha256: cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5
+        x-checker-data:
+          name: idna
+          packagetype: bdist_wheel
+          type: pypi
+      - type: file
+        url: https://files.pythonhosted.org/packages/a0/f4/requests-2.34.2-py3-none-any.whl
+        sha256: 2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0
+        x-checker-data:
+          name: requests
+          packagetype: bdist_wheel
+          type: pypi
+  - name: python3-flit_core
+    buildsystem: simple
+    build-commands:
+      - pip3 install flit_core
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/69/59/flit_core-3.12.0.tar.gz
+        sha256: 18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2
+        x-checker-data:
+          type: pypi
+          name: flit_core
+  - name: python3-flit_core_dup
+    buildsystem: simple
+    build-commands:
+      - pip3 install flit_core
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/69/59/flit_core-3.12.0.tar.gz
+        sha256: 18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2
+        x-checker-data:
+          type: pypi
+          name: flit_core
+      - *idna_anchor

--- a/tests/fedora_flatpak_updater/fixtures/root.yml
+++ b/tests/fedora_flatpak_updater/fixtures/root.yml
@@ -1,0 +1,40 @@
+modules:
+  - name: python3-idna
+    buildsystem: simple
+    build-commands:
+      - pip3 install idna
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/94/16/idna-3.16-py3-none-any.whl
+        sha256: cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5
+        x-checker-data:
+          name: idna
+          packagetype: bdist_wheel
+          type: pypi
+
+  # keep me: comment that must survive patching
+  - name: libndp
+    buildsystem: autotools
+    cleanup:
+      - /bin
+      - /include
+    sources:
+      - type: archive
+        url: https://github.com/jpirko/libndp/archive/v1.9.tar.gz
+        sha256: e564f5914a6b1b799c3afa64c258824a801c1b79a29e2fe6525b682249c65261
+        x-checker-data:
+          type: anitya
+          project-id: 14944
+          url-template: https://github.com/jpirko/libndp/archive/v$version.tar.gz
+
+  - name: python-proton-core
+    buildsystem: simple
+    build-commands:
+      - pip3 install .
+    modules:
+      - pip-resources.example.yaml
+    sources:
+      - type: git
+        url: https://github.com/ProtonVPN/python-proton-core
+        tag: v0.7.0
+        commit: f7a178a99c3adc0e88c7f91d4db5371a052c4985

--- a/tests/fedora_flatpak_updater/test_cli.py
+++ b/tests/fedora_flatpak_updater/test_cli.py
@@ -178,3 +178,73 @@ def test_main_module_execution(monkeypatch, manifest_root, mapping_file):
     with pytest.raises(SystemExit) as exc_info:
         runpy.run_module("fedora_flatpak_updater.__main__", run_name="__main__")
     assert exc_info.value.code == 0
+
+
+def test_main_command_exits_nonzero_on_mapping_failure(monkeypatch, manifest_root, mapping_file):
+    def raise_mapping_error(mapping, manifest, *, dry_run=False, only=None):
+        raise cli.MappingError("Invalid mapping configuration")
+
+    monkeypatch.setattr(cli, "run", raise_mapping_error)
+
+    result = CliRunner().invoke(cli.main, ["--mapping", str(mapping_file), "--manifest", str(manifest_root)])
+
+    assert result.exit_code == 1
+    assert "Invalid mapping configuration" in result.output
+
+
+def test_run_handles_network_exceptions_in_mdapi_and_recipes(monkeypatch, manifest_root, mapping_file):
+    monkeypatch.setattr(cli, "get_current_stable_branch", lambda session=None: "f44")
+
+    import requests
+    import subprocess
+
+    class FailingMdapi:
+        def __init__(self, branch, session=None):
+            pass
+        def get_version(self, package_name):
+            if package_name == "python3-idna":
+                raise requests.RequestException("MDAPI timeout")
+            return "9.9"
+
+    monkeypatch.setattr(cli, "MdapiClient", FailingMdapi)
+
+    def raise_request_err(*args, **kwargs):
+        raise requests.RequestException("Archive download failed")
+
+    def raise_subprocess_err(*args, **kwargs):
+        raise subprocess.SubprocessError("git command failed")
+
+    monkeypatch.setattr(cli.archive_recipe, "resolve", raise_request_err)
+    monkeypatch.setattr(cli.git_recipe, "resolve", raise_subprocess_err)
+
+    mapping_file.write_text(
+        """
+modules:
+  python3-idna:
+    fedora_package: python3-idna
+    recipe: pypi
+    pypi_name: idna
+  libndp:
+    fedora_package: libndp
+    recipe: archive
+    url_template: "https://github.com/jpirko/libndp/archive/v$version.tar.gz"
+  libgit:
+    fedora_package: libgit
+    recipe: git
+    repo_url: "https://x/git"
+    tag_template: "$version"
+"""
+    )
+
+    rows = cli.run(mapping_file, manifest_root, dry_run=True)
+    statuses = {row.module_name: row.status for row in rows}
+    details = {row.module_name: row.detail for row in rows}
+
+    assert statuses["python3-idna"] == "skipped"
+    assert "MDAPI timeout" in details["python3-idna"]
+
+    assert statuses["libndp"] == "skipped"
+    assert "Archive download failed" in details["libndp"]
+
+    assert statuses["libgit"] == "skipped"
+    assert "git command failed" in details["libgit"]

--- a/tests/fedora_flatpak_updater/test_cli.py
+++ b/tests/fedora_flatpak_updater/test_cli.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from importlib.metadata import entry_points
+from pathlib import Path
+import runpy
+import sys
+
+import pytest
+from click.testing import CliRunner
+
+from fedora_flatpak_updater import cli
+from fedora_flatpak_updater.mdapi_client import PackageNotFoundError
+from fedora_flatpak_updater.recipes.archive import ArchiveSource
+from fedora_flatpak_updater.recipes.pypi import PypiSource
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class FakeMdapi:
+    _VERSIONS = {"python3-idna": "3.99", "libndp": "9.9"}
+
+    def __init__(self, branch, session=None):
+        self.branch = branch
+
+    def get_version(self, package_name):
+        if package_name not in self._VERSIONS:
+            raise PackageNotFoundError(package_name, self.branch)
+        return self._VERSIONS[package_name]
+
+
+@pytest.fixture
+def manifest_root(tmp_path):
+    for name in ("root.yml", "pip-resources.example.yaml"):
+        (tmp_path / name).write_text((FIXTURES / name).read_text())
+    return tmp_path / "root.yml"
+
+
+@pytest.fixture
+def mapping_file(tmp_path):
+    path = tmp_path / ".fedora-tracked-modules.yaml"
+    path.write_text(
+        """
+modules:
+  python3-idna:
+    fedora_package: python3-idna
+    recipe: pypi
+    pypi_name: idna
+  libndp:
+    fedora_package: libndp
+    recipe: archive
+    url_template: "https://github.com/jpirko/libndp/archive/v$version.tar.gz"
+  python3-nonexistent:
+    fedora_package: python3-nonexistent
+    recipe: pypi
+    pypi_name: nonexistent
+"""
+    )
+    return path
+
+
+def _patch_common(monkeypatch):
+    monkeypatch.setattr(cli, "get_current_stable_branch", lambda session=None: "f44")
+    monkeypatch.setattr(cli, "MdapiClient", FakeMdapi)
+    monkeypatch.setattr(
+        cli.pypi_recipe,
+        "resolve",
+        lambda pypi_name, version, prefer="wheel", session=None: PypiSource(
+            url=f"https://x/{pypi_name}-{version}-py3-none-any.whl", sha256="deadbeef"
+        ),
+    )
+    monkeypatch.setattr(
+        cli.archive_recipe,
+        "resolve",
+        lambda url_template, version, session=None: ArchiveSource(
+            url=f"https://x/libndp-{version}.tar.gz", sha256="cafef00d"
+        ),
+    )
+
+
+def test_run_reports_updated_and_skipped_modules(monkeypatch, manifest_root, mapping_file):
+    _patch_common(monkeypatch)
+
+    rows = cli.run(mapping_file, manifest_root, dry_run=True)
+
+    statuses = {row.module_name: row.status for row in rows}
+    assert statuses["python3-idna"] == "updated"
+    assert statuses["libndp"] == "updated"
+    assert statuses["python3-nonexistent"] == "skipped"
+
+
+def test_dry_run_does_not_write_files(monkeypatch, manifest_root, mapping_file):
+    _patch_common(monkeypatch)
+    original_text = manifest_root.read_text()
+
+    cli.run(mapping_file, manifest_root, dry_run=True, only=["python3-idna"])
+
+    assert manifest_root.read_text() == original_text
+
+
+def test_non_dry_run_writes_updated_files(monkeypatch, manifest_root, mapping_file):
+    _patch_common(monkeypatch)
+
+    cli.run(mapping_file, manifest_root, dry_run=False, only=["python3-idna"])
+
+    assert "idna-3.99-py3-none-any.whl" in manifest_root.read_text()
+
+
+def test_format_summary_produces_a_github_markdown_table(monkeypatch, manifest_root, mapping_file):
+    _patch_common(monkeypatch)
+    rows = cli.run(mapping_file, manifest_root, dry_run=True)
+
+    summary = cli.format_summary(rows)
+
+    assert "| Module" in summary
+    assert "python3-idna" in summary
+    assert "python3-nonexistent" in summary
+
+
+def test_main_command_wires_flags_into_run(monkeypatch, manifest_root, mapping_file):
+    captured = {}
+
+    def fake_run(mapping, manifest, *, dry_run=False, only=None):
+        captured["dry_run"] = dry_run
+        captured["only"] = only
+        return [cli.Row("python3-idna", "updated", "-> 3.99 (1 block(s))")]
+
+    monkeypatch.setattr(cli, "run", fake_run)
+
+    result = CliRunner().invoke(
+        cli.main,
+        [
+            "--mapping", str(mapping_file),
+            "--manifest", str(manifest_root),
+            "--dry-run",
+            "--only", "python3-idna",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "python3-idna" in result.output
+    assert captured["dry_run"] is True
+    assert captured["only"] == ["python3-idna"]
+
+
+def test_main_command_exits_nonzero_on_bodhi_failure(monkeypatch, manifest_root, mapping_file):
+    def raise_bodhi_error(mapping, manifest, *, dry_run=False, only=None):
+        raise cli.BodhiLookupError("Bodhi is down")
+
+    monkeypatch.setattr(cli, "run", raise_bodhi_error)
+
+    result = CliRunner().invoke(cli.main, ["--mapping", str(mapping_file), "--manifest", str(manifest_root)])
+
+    assert result.exit_code == 1
+    assert "Bodhi is down" in result.output
+
+
+def test_entry_point_wired():
+    eps = entry_points(group="console_scripts")
+    matching = [ep for ep in eps if ep.name == "fedora-flatpak-updater"]
+    assert len(matching) == 1
+    assert matching[0].value == "fedora_flatpak_updater.cli:main"
+
+
+def test_main_module_execution(monkeypatch, manifest_root, mapping_file):
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "fedora-flatpak-updater",
+            "--mapping",
+            str(mapping_file),
+            "--manifest",
+            str(manifest_root),
+            "--dry-run",
+        ],
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_module("fedora_flatpak_updater.__main__", run_name="__main__")
+    assert exc_info.value.code == 0

--- a/tests/fedora_flatpak_updater/test_fedora_release.py
+++ b/tests/fedora_flatpak_updater/test_fedora_release.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+import requests
+import responses
+
+from fedora_flatpak_updater.fedora_release import BodhiLookupError, get_current_stable_branch
+
+BODHI_URL = "https://bodhi.fedoraproject.org/releases/"
+
+SAMPLE_PAYLOAD = {
+    "releases": [
+        {"id_prefix": "FEDORA", "version": "43", "released_on": "2025-04-15", "state": "current"},
+        {"id_prefix": "FEDORA", "version": "44", "released_on": "2025-11-11", "state": "current"},
+        {"id_prefix": "FEDORA", "version": "45", "released_on": None, "state": "current"},
+        {"id_prefix": "FEDORA-CONTAINER", "version": "44", "released_on": "2025-11-11", "state": "current"},
+        {"id_prefix": "FEDORA-FLATPAK", "version": "44", "released_on": "2025-11-11", "state": "current"},
+        {"id_prefix": "FEDORA-EPEL", "version": "9", "released_on": "2022-01-01", "state": "current"},
+    ]
+}
+
+
+@responses.activate
+def test_picks_highest_released_fedora_version():
+    responses.add(responses.GET, BODHI_URL, json=SAMPLE_PAYLOAD, status=200)
+    assert get_current_stable_branch() == "f44"
+
+
+@responses.activate
+def test_retries_once_on_transient_failure_then_succeeds():
+    responses.add(responses.GET, BODHI_URL, body=requests.exceptions.ConnectionError("network blip"))
+    responses.add(responses.GET, BODHI_URL, json=SAMPLE_PAYLOAD, status=200)
+    assert get_current_stable_branch() == "f44"
+
+
+@responses.activate
+def test_raises_bodhi_lookup_error_after_exhausting_retries():
+    responses.add(responses.GET, BODHI_URL, body=requests.exceptions.ConnectionError("still broken"))
+    responses.add(responses.GET, BODHI_URL, body=requests.exceptions.ConnectionError("still broken"))
+    with pytest.raises(BodhiLookupError):
+        get_current_stable_branch()
+
+
+@responses.activate
+def test_raises_bodhi_lookup_error_when_no_current_release_found():
+    responses.add(responses.GET, BODHI_URL, json={"releases": []}, status=200)
+    with pytest.raises(BodhiLookupError):
+        get_current_stable_branch()

--- a/tests/fedora_flatpak_updater/test_manifest_patcher.py
+++ b/tests/fedora_flatpak_updater/test_manifest_patcher.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fedora_flatpak_updater.manifest_patcher import (
+    ManifestForest,
+    apply_archive,
+    apply_git,
+    apply_pypi,
+    find_module_blocks,
+    find_pypi_source_blocks,
+)
+from fedora_flatpak_updater.models import ModuleSpec, RecipeKind
+from fedora_flatpak_updater.recipes.archive import ArchiveSource
+from fedora_flatpak_updater.recipes.git import GitSource
+from fedora_flatpak_updater.recipes.pypi import PypiSource
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _fresh_forest(tmp_path: Path) -> ManifestForest:
+    for name in ("root.yml", "pip-resources.example.yaml"):
+        (tmp_path / name).write_text((FIXTURES / name).read_text())
+    return ManifestForest(tmp_path / "root.yml")
+
+
+def test_find_pypi_source_blocks_finds_every_occurrence_across_files(tmp_path):
+    forest = _fresh_forest(tmp_path)
+    blocks = find_pypi_source_blocks(forest, "idna")
+    assert len(blocks) == 2  # root.yml's own block + the shared anchor/alias block
+
+
+def test_apply_pypi_updates_every_occurrence_and_strips_checker_data(tmp_path):
+    forest = _fresh_forest(tmp_path)
+    spec = ModuleSpec(name="python3-idna", fedora_package="python3-idna", recipe=RecipeKind.PYPI, pypi_name="idna")
+    new_source = PypiSource(url="https://files.pythonhosted.org/idna-3.11-py3-none-any.whl", sha256="deadbeef")
+
+    report = apply_pypi(forest, spec, lambda block: new_source)
+
+    assert report.blocks_touched == 2
+    for block in find_pypi_source_blocks(forest, "idna"):
+        assert block["url"] == new_source.url
+        assert block["sha256"] == new_source.sha256
+        assert "x-checker-data" not in block
+
+
+def test_apply_pypi_leaves_unrelated_packages_untouched(tmp_path):
+    forest = _fresh_forest(tmp_path)
+    spec = ModuleSpec(name="python3-idna", fedora_package="python3-idna", recipe=RecipeKind.PYPI, pypi_name="idna")
+    apply_pypi(forest, spec, lambda block: PypiSource(url="https://x/idna-3.11-py3-none-any.whl", sha256="deadbeef"))
+
+    [requests_block] = find_pypi_source_blocks(forest, "requests")
+    assert requests_block["sha256"] == "2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"
+    assert requests_block["x-checker-data"]["name"] == "requests"
+
+
+def test_apply_pypi_updates_duplicate_module_occurrences_independently(tmp_path):
+    forest = _fresh_forest(tmp_path)
+    spec = ModuleSpec(name="python3-flit_core", fedora_package="python3-flit_core", recipe=RecipeKind.PYPI, pypi_name="flit_core")
+    new_source = PypiSource(url="https://x/flit_core-4.0.0.tar.gz", sha256="cafef00d")
+
+    report = apply_pypi(forest, spec, lambda block: new_source)
+
+    assert report.blocks_touched == 2
+    assert all(b["url"] == new_source.url for b in find_pypi_source_blocks(forest, "flit_core"))
+
+
+def test_apply_archive_updates_module_matched_by_name(tmp_path):
+    forest = _fresh_forest(tmp_path)
+    spec = ModuleSpec(
+        name="libndp",
+        fedora_package="libndp",
+        recipe=RecipeKind.ARCHIVE,
+        url_template="https://github.com/jpirko/libndp/archive/v$version.tar.gz",
+    )
+    source = ArchiveSource(url="https://github.com/jpirko/libndp/archive/v1.10.tar.gz", sha256="abc123")
+
+    report = apply_archive(forest, spec, source)
+
+    assert report.blocks_touched == 1
+    [module] = find_module_blocks(forest, "libndp")
+    [src] = module["sources"]
+    assert src["url"] == source.url
+    assert src["sha256"] == source.sha256
+    assert "x-checker-data" not in src
+
+
+def test_apply_git_updates_tag_and_commit(tmp_path):
+    forest = _fresh_forest(tmp_path)
+    spec = ModuleSpec(
+        name="python-proton-core",
+        fedora_package="python-proton-core",
+        recipe=RecipeKind.GIT,
+        repo_url="https://github.com/ProtonVPN/python-proton-core",
+        tag_template="v$version",
+    )
+    source = GitSource(tag="v0.8.0", commit="a" * 40)
+
+    report = apply_git(forest, spec, source)
+
+    assert report.blocks_touched == 1
+    [module] = find_module_blocks(forest, "python-proton-core")
+    [src] = module["sources"]
+    assert src["tag"] == "v0.8.0"
+    assert src["commit"] == "a" * 40
+
+
+def test_save_preserves_comments_and_unrelated_structure(tmp_path):
+    forest = _fresh_forest(tmp_path)
+    spec = ModuleSpec(name="python3-idna", fedora_package="python3-idna", recipe=RecipeKind.PYPI, pypi_name="idna")
+    apply_pypi(forest, spec, lambda block: PypiSource(url="https://x/idna-3.11-py3-none-any.whl", sha256="deadbeef"))
+    forest.save()
+
+    root_text = (tmp_path / "root.yml").read_text()
+    assert "keep me: comment that must survive patching" in root_text
+    assert "buildsystem: autotools" in root_text
+    assert "cleanup:" in root_text

--- a/tests/fedora_flatpak_updater/test_manifest_patcher.py
+++ b/tests/fedora_flatpak_updater/test_manifest_patcher.py
@@ -142,3 +142,11 @@ def test_remove_checker_data_concatenates_comments(tmp_path):
     assert "x-checker-data:" not in saved
     assert "type: pypi" not in saved
 
+
+def test_matches_pypi_name_prefix_isolation():
+    from fedora_flatpak_updater.manifest_patcher import _matches_pypi_name
+    assert _matches_pypi_name("https://example.com/requests-2.31.0.tar.gz", "requests") is True
+    assert _matches_pypi_name("https://example.com/requests-2.31.0-py3-none-any.whl", "requests") is True
+    assert _matches_pypi_name("https://example.com/requests-mock-1.0.0.tar.gz", "requests") is False
+    assert _matches_pypi_name("https://example.com/requests_mock-1.0.0-py3-none-any.whl", "requests") is False
+

--- a/tests/fedora_flatpak_updater/test_manifest_patcher.py
+++ b/tests/fedora_flatpak_updater/test_manifest_patcher.py
@@ -115,3 +115,30 @@ def test_save_preserves_comments_and_unrelated_structure(tmp_path):
     assert "keep me: comment that must survive patching" in root_text
     assert "buildsystem: autotools" in root_text
     assert "cleanup:" in root_text
+
+
+def test_remove_checker_data_concatenates_comments(tmp_path):
+    yaml_content = """modules:
+  - name: test-mod
+    sources:
+      - type: file
+        url: https://example.com/foo-1.0.whl
+        sha256: 1234  # existing comment on sha256
+        x-checker-data:
+          type: pypi
+          name: foo
+        # trailing comment from checker block
+"""
+    test_file = tmp_path / "test.yml"
+    test_file.write_text(yaml_content)
+    forest = ManifestForest(test_file)
+    spec = ModuleSpec(name="test-mod", fedora_package="test-mod", recipe=RecipeKind.PYPI, pypi_name="foo")
+    apply_pypi(forest, spec, lambda block: PypiSource(url="https://example.com/foo-2.0.whl", sha256="5678"))
+    forest.save()
+
+    saved = test_file.read_text()
+    assert "# existing comment on sha256" in saved
+    assert "# trailing comment from checker block" in saved
+    assert "x-checker-data:" not in saved
+    assert "type: pypi" not in saved
+

--- a/tests/fedora_flatpak_updater/test_mapping_loader.py
+++ b/tests/fedora_flatpak_updater/test_mapping_loader.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fedora_flatpak_updater.mapping_loader import MappingError, load_mapping
+from fedora_flatpak_updater.models import RecipeKind
+
+
+def test_load_mapping_parses_all_recipe_kinds(tmp_path: Path):
+    mapping_file = tmp_path / ".fedora-tracked-modules.yaml"
+    mapping_file.write_text(
+        """
+modules:
+  python3-idna:
+    fedora_package: python3-idna
+    recipe: pypi
+    pypi_name: idna
+    prefer: wheel
+  python3-cryptography:
+    fedora_package: python3-cryptography
+    recipe: pypi-multi-wheel
+    pypi_name: cryptography
+    wheel_arches: [aarch64, x86_64]
+  libndp:
+    fedora_package: libndp
+    recipe: archive
+    url_template: "https://github.com/jpirko/libndp/archive/v$version.tar.gz"
+  NetworkManager:
+    fedora_package: NetworkManager
+    recipe: git
+    repo_url: "https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git"
+    tag_template: "$version"
+  python3-bcrypt:
+    fedora_package: python3-bcrypt
+    recipe: pypi
+    pypi_name: bcrypt
+    manual_followup: "regenerate bcrypt-cargo-sources.json"
+"""
+    )
+
+    specs = load_mapping(mapping_file)
+    by_name = {spec.name: spec for spec in specs}
+
+    assert by_name["python3-idna"].recipe == RecipeKind.PYPI
+    assert by_name["python3-idna"].pypi_name == "idna"
+
+    assert by_name["python3-cryptography"].recipe == RecipeKind.PYPI_MULTI_WHEEL
+    assert by_name["python3-cryptography"].wheel_arches == ("aarch64", "x86_64")
+
+    assert by_name["libndp"].recipe == RecipeKind.ARCHIVE
+    assert by_name["libndp"].url_template.endswith("v$version.tar.gz")
+
+    assert by_name["NetworkManager"].recipe == RecipeKind.GIT
+    assert by_name["NetworkManager"].tag_template == "$version"
+
+    assert by_name["python3-bcrypt"].manual_followup == "regenerate bcrypt-cargo-sources.json"
+
+
+def test_load_mapping_rejects_missing_recipe(tmp_path: Path):
+    mapping_file = tmp_path / ".fedora-tracked-modules.yaml"
+    mapping_file.write_text(
+        """
+modules:
+  broken:
+    fedora_package: broken
+"""
+    )
+    with pytest.raises(MappingError):
+        load_mapping(mapping_file)
+
+
+def test_load_mapping_rejects_missing_fedora_package(tmp_path: Path):
+    mapping_file = tmp_path / ".fedora-tracked-modules.yaml"
+    mapping_file.write_text(
+        """
+modules:
+  broken:
+    recipe: pypi
+    pypi_name: broken
+"""
+    )
+    with pytest.raises(MappingError):
+        load_mapping(mapping_file)

--- a/tests/fedora_flatpak_updater/test_mdapi_client.py
+++ b/tests/fedora_flatpak_updater/test_mdapi_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+import requests
 import responses
 
 from fedora_flatpak_updater.mdapi_client import MdapiClient, MdapiTransientError, PackageNotFoundError
@@ -61,6 +62,17 @@ def test_get_version_raises_transient_error_after_two_5xx():
     url = "https://mdapi.fedoraproject.org/f44/pkg/libndp"
     responses.add(responses.GET, url, status=502)
     responses.add(responses.GET, url, status=502)
+
+    client = MdapiClient("f44")
+    with pytest.raises(MdapiTransientError):
+        client.get_version("libndp")
+
+
+@responses.activate
+def test_get_version_retries_and_raises_transient_error_on_connection_error():
+    url = "https://mdapi.fedoraproject.org/f44/pkg/libndp"
+    responses.add(responses.GET, url, body=requests.ConnectionError("Connection aborted"))
+    responses.add(responses.GET, url, body=requests.ConnectionError("Connection aborted"))
 
     client = MdapiClient("f44")
     with pytest.raises(MdapiTransientError):

--- a/tests/fedora_flatpak_updater/test_mdapi_client.py
+++ b/tests/fedora_flatpak_updater/test_mdapi_client.py
@@ -37,6 +37,16 @@ def test_get_version_raises_package_not_found_on_404():
 
 
 @responses.activate
+def test_get_version_raises_package_not_found_on_400():
+    url = "https://mdapi.fedoraproject.org/f44/pkg/python3-meson"
+    responses.add(responses.GET, url, status=400)
+
+    client = MdapiClient("f44")
+    with pytest.raises(PackageNotFoundError):
+        client.get_version("python3-meson")
+
+
+@responses.activate
 def test_get_version_retries_once_on_5xx_then_succeeds():
     url = "https://mdapi.fedoraproject.org/f44/pkg/libndp"
     responses.add(responses.GET, url, status=502)

--- a/tests/fedora_flatpak_updater/test_mdapi_client.py
+++ b/tests/fedora_flatpak_updater/test_mdapi_client.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pytest
+import responses
+
+from fedora_flatpak_updater.mdapi_client import MdapiClient, MdapiTransientError, PackageNotFoundError
+
+
+@responses.activate
+def test_get_version_returns_version_field():
+    url = "https://mdapi.fedoraproject.org/f44/pkg/python3-cryptography"
+    responses.add(responses.GET, url, json={"version": "46.0.7"}, status=200)
+
+    client = MdapiClient("f44")
+    assert client.get_version("python3-cryptography") == "46.0.7"
+
+
+@responses.activate
+def test_get_version_caches_repeat_calls():
+    url = "https://mdapi.fedoraproject.org/f44/pkg/python3-cryptography"
+    responses.add(responses.GET, url, json={"version": "46.0.7"}, status=200)
+
+    client = MdapiClient("f44")
+    client.get_version("python3-cryptography")
+    client.get_version("python3-cryptography")
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_get_version_raises_package_not_found_on_404():
+    url = "https://mdapi.fedoraproject.org/f44/pkg/python3-does-not-exist"
+    responses.add(responses.GET, url, status=404)
+
+    client = MdapiClient("f44")
+    with pytest.raises(PackageNotFoundError):
+        client.get_version("python3-does-not-exist")
+
+
+@responses.activate
+def test_get_version_retries_once_on_5xx_then_succeeds():
+    url = "https://mdapi.fedoraproject.org/f44/pkg/libndp"
+    responses.add(responses.GET, url, status=502)
+    responses.add(responses.GET, url, json={"version": "1.10"}, status=200)
+
+    client = MdapiClient("f44")
+    assert client.get_version("libndp") == "1.10"
+
+
+@responses.activate
+def test_get_version_raises_transient_error_after_two_5xx():
+    url = "https://mdapi.fedoraproject.org/f44/pkg/libndp"
+    responses.add(responses.GET, url, status=502)
+    responses.add(responses.GET, url, status=502)
+
+    client = MdapiClient("f44")
+    with pytest.raises(MdapiTransientError):
+        client.get_version("libndp")

--- a/tests/fedora_flatpak_updater/test_mdapi_client.py
+++ b/tests/fedora_flatpak_updater/test_mdapi_client.py
@@ -77,3 +77,24 @@ def test_get_version_retries_and_raises_transient_error_on_connection_error():
     client = MdapiClient("f44")
     with pytest.raises(MdapiTransientError):
         client.get_version("libndp")
+
+
+@responses.activate
+def test_get_version_retries_once_on_429_then_succeeds():
+    url = "https://mdapi.fedoraproject.org/f44/pkg/libndp"
+    responses.add(responses.GET, url, status=429)
+    responses.add(responses.GET, url, json={"version": "1.10"}, status=200)
+
+    client = MdapiClient("f44")
+    assert client.get_version("libndp") == "1.10"
+
+
+@responses.activate
+def test_get_version_raises_transient_error_after_two_429():
+    url = "https://mdapi.fedoraproject.org/f44/pkg/libndp"
+    responses.add(responses.GET, url, status=429)
+    responses.add(responses.GET, url, status=429)
+
+    client = MdapiClient("f44")
+    with pytest.raises(MdapiTransientError):
+        client.get_version("libndp")

--- a/tests/fedora_flatpak_updater/test_recipes_archive.py
+++ b/tests/fedora_flatpak_updater/test_recipes_archive.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+import responses
+
+from fedora_flatpak_updater.recipes.archive import ArchiveResolutionError, render_url, resolve
+
+
+def test_render_url_substitutes_version():
+    rendered = render_url("https://github.com/jpirko/libndp/archive/v$version.tar.gz", "1.10")
+    assert rendered == "https://github.com/jpirko/libndp/archive/v1.10.tar.gz"
+
+
+@responses.activate
+def test_resolve_computes_sha256_of_downloaded_content():
+    content = b"fake tarball bytes"
+    url = "https://github.com/jpirko/libndp/archive/v1.10.tar.gz"
+    responses.add(responses.GET, url, body=content, status=200)
+
+    source = resolve("https://github.com/jpirko/libndp/archive/v$version.tar.gz", "1.10")
+
+    assert source.url == url
+    assert source.sha256 == hashlib.sha256(content).hexdigest()
+
+
+@responses.activate
+def test_resolve_raises_on_404():
+    url = "https://gitlab.freedesktop.org/polkit/polkit/-/archive/127/polkit-127.tar.gz"
+    responses.add(responses.GET, url, status=404)
+
+    with pytest.raises(ArchiveResolutionError):
+        resolve(
+            "https://gitlab.freedesktop.org/polkit/polkit/-/archive/$version/polkit-$version.tar.gz",
+            "127",
+        )

--- a/tests/fedora_flatpak_updater/test_recipes_git.py
+++ b/tests/fedora_flatpak_updater/test_recipes_git.py
@@ -59,3 +59,19 @@ def test_resolve_raises_when_tag_not_found():
             tag_template="$version",
             runner=_runner_returning(NETWORKMANAGER_LS_REMOTE),
         )
+
+
+def test_resolve_ignores_lines_without_tabs():
+    output_with_noise = (
+        "warning: some git warning here\n"
+        "2db3748ec8162ce948ba52f71b42a258ff8d64ba\trefs/tags/1.40.18\n"
+    )
+    source = resolve(
+        repo_url="https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git",
+        version="1.40.18",
+        tag_template="$version",
+        runner=_runner_returning(output_with_noise),
+    )
+    assert source.tag == "1.40.18"
+    assert source.commit == "2db3748ec8162ce948ba52f71b42a258ff8d64ba"
+

--- a/tests/fedora_flatpak_updater/test_recipes_git.py
+++ b/tests/fedora_flatpak_updater/test_recipes_git.py
@@ -75,3 +75,14 @@ def test_resolve_ignores_lines_without_tabs():
     assert source.tag == "1.40.18"
     assert source.commit == "2db3748ec8162ce948ba52f71b42a258ff8d64ba"
 
+
+def test_resolve_by_tag_pattern_without_capture_group():
+    source = resolve(
+        repo_url="https://github.com/systemd/systemd.git",
+        version="v260.2",
+        tag_pattern=r"^v\d+\.\d+$",
+        runner=_runner_returning(SYSTEMD_LS_REMOTE),
+    )
+    assert source.tag == "v260.2"
+    assert source.commit == "e" * 40
+

--- a/tests/fedora_flatpak_updater/test_recipes_git.py
+++ b/tests/fedora_flatpak_updater/test_recipes_git.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+
+from fedora_flatpak_updater.recipes.git import GitTagNotFoundError, resolve
+
+NETWORKMANAGER_LS_REMOTE = (
+    "2db3748ec8162ce948ba52f71b42a258ff8d64ba\trefs/tags/1.40.18\n"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\trefs/tags/1.54.3\n"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\trefs/tags/1.54.3^{}\n"
+)
+
+SYSTEMD_LS_REMOTE = (
+    "cccccccccccccccccccccccccccccccccccccccc\trefs/tags/v259.0\n"
+    "dddddddddddddddddddddddddddddddddddddddd\trefs/tags/v260.2\n"
+    "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\trefs/tags/v260.2^{}\n"
+)
+
+
+class _FakeCompleted:
+    def __init__(self, stdout: str):
+        self.stdout = stdout
+
+
+def _runner_returning(stdout: str):
+    def runner(*args, **kwargs):
+        return _FakeCompleted(stdout)
+
+    return runner
+
+
+def test_resolve_by_tag_template_prefers_peeled_hash():
+    source = resolve(
+        repo_url="https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git",
+        version="1.54.3",
+        tag_template="$version",
+        runner=_runner_returning(NETWORKMANAGER_LS_REMOTE),
+    )
+    assert source.tag == "1.54.3"
+    assert source.commit == "b" * 40
+
+
+def test_resolve_by_tag_pattern_matches_captured_version():
+    source = resolve(
+        repo_url="https://github.com/systemd/systemd.git",
+        version="260.2",
+        tag_pattern=r"^v([\d.]+)$",
+        runner=_runner_returning(SYSTEMD_LS_REMOTE),
+    )
+    assert source.tag == "v260.2"
+    assert source.commit == "e" * 40
+
+
+def test_resolve_raises_when_tag_not_found():
+    with pytest.raises(GitTagNotFoundError):
+        resolve(
+            repo_url="https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git",
+            version="99.0.0",
+            tag_template="$version",
+            runner=_runner_returning(NETWORKMANAGER_LS_REMOTE),
+        )

--- a/tests/fedora_flatpak_updater/test_recipes_pypi.py
+++ b/tests/fedora_flatpak_updater/test_recipes_pypi.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+import responses
+
+from fedora_flatpak_updater.recipes.pypi import (
+    PypiVersionNotFoundError,
+    resolve,
+    resolve_multi_wheel,
+    resolve_sdist,
+    resolve_wheel,
+)
+
+IDNA_URL = "https://pypi.org/pypi/idna/3.11/json"
+IDNA_JSON = {
+    "urls": [
+        {
+            "packagetype": "sdist",
+            "url": "https://files.pythonhosted.org/packages/.../idna-3.11.tar.gz",
+            "digests": {"sha256": "sdist" + "0" * 59},
+        },
+        {
+            "packagetype": "bdist_wheel",
+            "filename": "idna-3.11-py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/.../idna-3.11-py3-none-any.whl",
+            "digests": {"sha256": "wheel" + "0" * 59},
+        },
+    ]
+}
+
+CRYPTOGRAPHY_URL = "https://pypi.org/pypi/cryptography/46.0.7/json"
+CRYPTOGRAPHY_JSON = {
+    "urls": [
+        {
+            "packagetype": "bdist_wheel",
+            "filename": "cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl",
+            "url": "https://files.pythonhosted.org/.../cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl",
+            "digests": {"sha256": "aarch64" + "0" * 57},
+        },
+        {
+            "packagetype": "bdist_wheel",
+            "filename": "cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl",
+            "url": "https://files.pythonhosted.org/.../cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl",
+            "digests": {"sha256": "x86_64" + "0" * 58},
+        },
+    ]
+}
+
+
+@responses.activate
+def test_resolve_wheel_picks_bdist_wheel_entry():
+    responses.add(responses.GET, IDNA_URL, json=IDNA_JSON, status=200)
+    source = resolve_wheel("idna", "3.11")
+    assert source.url.endswith(".whl")
+    assert source.sha256.startswith("wheel")
+
+
+@responses.activate
+def test_resolve_sdist_picks_sdist_entry():
+    responses.add(responses.GET, IDNA_URL, json=IDNA_JSON, status=200)
+    source = resolve_sdist("idna", "3.11")
+    assert source.url.endswith(".tar.gz")
+    assert source.sha256.startswith("sdist")
+
+
+@responses.activate
+def test_resolve_prefers_wheel_by_default():
+    responses.add(responses.GET, IDNA_URL, json=IDNA_JSON, status=200)
+    source = resolve("idna", "3.11")
+    assert source.url.endswith(".whl")
+
+
+@responses.activate
+def test_resolve_falls_back_to_sdist_when_no_wheel_available():
+    payload = {"urls": [IDNA_JSON["urls"][0]]}  # sdist only
+    responses.add(responses.GET, IDNA_URL, json=payload, status=200)
+    source = resolve("idna", "3.11", prefer="wheel")
+    assert source.url.endswith(".tar.gz")
+
+
+@responses.activate
+def test_resolve_raises_when_version_missing_on_pypi():
+    responses.add(responses.GET, "https://pypi.org/pypi/idna/999.0/json", status=404)
+    with pytest.raises(PypiVersionNotFoundError):
+        resolve("idna", "999.0")
+
+
+@responses.activate
+def test_resolve_multi_wheel_selects_one_wheel_per_arch():
+    responses.add(responses.GET, CRYPTOGRAPHY_URL, json=CRYPTOGRAPHY_JSON, status=200)
+    result = resolve_multi_wheel("cryptography", "46.0.7", ("aarch64", "x86_64"))
+    assert result["aarch64"].sha256.startswith("aarch64")
+    assert result["x86_64"].sha256.startswith("x86_64")
+    assert result["aarch64"].only_arches == ("aarch64",)


### PR DESCRIPTION
This PR adds the fedora-flatpak-updater package and orchestration scripts, as well as test suites and CI workflows, pinning dependencies to Fedora's latest stable release versions.