### PR TITLE
revert NetworkManager version to 1.40.18

### DIFF
--- a/com.protonvpn.www.yml
+++ b/com.protonvpn.www.yml
@@ -190,59 +190,62 @@ modules:
     sha256: 9b7bc16f086479dcc626c575976568ba4a85d34297a750d8ab3d2e57f6d8b988
 
   # https://github.com/flathub/org.gnome.NetworkDisplays/blob/5a3369d04e32ccd092e42463de5171f473a8601d/org.gnome.NetworkDisplays.json#LL177C11-L230C11
-- name: NetworkManager
-  buildsystem: meson
-  build-options:
-    cflags: -ltinfo
-    cxxflags: -ltinfo
-  config-opts:
-  - -Dsystemdsystemunitdir=no
-  - -Ddbus_conf_dir=/app/etc/dbus-1/system.d
-  - -Diptables=/usr/bin/true
-  - -Ddnsmasq=/usr/bin/true
-  - -Dsession_tracking=no
-  - -Dselinux=false
-  - -Dsystemd_journal=false
-  - -Dlibaudit=no
-  - -Dwext=false
-  - -Dwifi=false
-  - -Dppp=false
-  - -Dmodem_manager=false
-  - -Dovs=false
-  - -Dnmcli=false
-  - -Dnmtui=false
+  - name: NetworkManager
+    buildsystem: meson
+    build-options:
+      cflags: -ltinfo
+      cxxflags: -ltinfo
+    config-opts:
+      - -Dsystemdsystemunitdir=no
+      - -Ddbus_conf_dir=/app/etc/dbus-1/system.d
+      - -Diptables=/usr/bin/true
+      - -Ddnsmasq=/usr/bin/true
+      - -Dsession_tracking=no
+      - -Dselinux=false
+      - -Dsystemd_journal=false
+      - -Dlibaudit=no
+      - -Dwext=false
+      - -Dwifi=false
+      - -Dppp=false
+      - -Dmodem_manager=false
+      - -Dovs=false
+      - -Dnmcli=false
+      - -Dnmtui=false
       # We need introspection
-  - -Dintrospection=true
-  - -Dvapi=false
-  - -Ddocs=false
-  - -Dtests=no
-  - -Dfirewalld_zone=false
-  - -Dlibpsl=false
-  - -Dqt=false
-  - -Dnm_cloud_setup=false
-  - -Dnbft=false
-  - -Dsession_tracking_consolekit=false
-  - -Dpolkit=false
-  - -Dconcheck=false
-  - -Debpf=false
-  - -Dman=false
-  - -Dreadline=none
-  cleanup:
-  - /sbin
-  - /etc
-  - /include
-  - /lib/pkgconfig
-  - /libexec
-  - /var
-  - /share/bash-completion
-  - /share/doc
-  sources:
-  - type: git
-    url: https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git
-    tag: 1.40.18
-    commit: 2db3748ec8162ce948ba52f71b42a258ff8d64ba
-  - type: patch
-    path: patches/NetworkManager/disable-ownership-check-for-plugins.patch
+      - -Dintrospection=true
+      - -Dvapi=false
+      - -Ddocs=false
+      - -Dtests=no
+      - -Dfirewalld_zone=false
+      - -Dlibpsl=false
+      - -Dqt=false
+    cleanup:
+      - /sbin
+      - /etc
+      - /include
+      - /lib/pkgconfig
+      - /libexec
+      - /var
+      - /share/bash-completion
+      - /share/doc
+    sources:
+      - type: git
+        url: https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git
+        tag: 1.40.18
+        commit: 2db3748ec8162ce948ba52f71b42a258ff8d64ba
+        x-checker-data:
+          type: anitya
+          project-id: 21197
+          stable-only: true
+          tag-template: $version
+          versions:
+            # Breaking change in 1.42.x: `dns` will be replaced by `dns-data`, which is incompatible with older NetworkManager on the host system
+            <: 1.42.0
+
+      # To fix `Support for given configuration is not implemented` when trying to connect: https://github.com/flathub/com.protonvpn.www/issues/2
+      # Copied from https://github.com/flathub/com.github.jkotra.eovpn/blob/670f19e2aee1c9559fbe4eed904e35500843ae88/0001-disable-ownership-check-for-plugins.patch
+      - type: patch
+        path: patches/NetworkManager/disable-ownership-check-for-plugins.patch
 
   # https://github.com/flathub/com.github.jkotra.eovpn/blob/670f19e2aee1c9559fbe4eed904e35500843ae88/com.github.jkotra.eovpn.yml#L133C17-L151
 - name: libnma

--- a/com.protonvpn.www.yml
+++ b/com.protonvpn.www.yml
@@ -267,8 +267,16 @@ modules:
   sources:
   - type: git
     url: https://github.com/NetworkManager/NetworkManager-openvpn.git
-    tag: 1.12.5
-    commit: d03d6a636866e9be9fbec7977ef377c191fb2988 # 1.10.4 causes connection failure
+    tag: 1.10.2
+    commit: ae9575dd07cc2d2d51ec8d0297823e07017cb6e6
+    x-checker-data:
+      type: anitya
+      project-id: 69977
+      stable-only: true
+      tag-template: $version
+      versions:
+        # 1.10.4 causes connection failure
+        <: 1.10.4
 - name: systemd
   buildsystem: meson
   config-opts:

--- a/com.protonvpn.www.yml
+++ b/com.protonvpn.www.yml
@@ -190,62 +190,62 @@ modules:
     sha256: 9b7bc16f086479dcc626c575976568ba4a85d34297a750d8ab3d2e57f6d8b988
 
   # https://github.com/flathub/org.gnome.NetworkDisplays/blob/5a3369d04e32ccd092e42463de5171f473a8601d/org.gnome.NetworkDisplays.json#LL177C11-L230C11
-  - name: NetworkManager
-    buildsystem: meson
-    build-options:
-      cflags: -ltinfo
-      cxxflags: -ltinfo
-    config-opts:
-      - -Dsystemdsystemunitdir=no
-      - -Ddbus_conf_dir=/app/etc/dbus-1/system.d
-      - -Diptables=/usr/bin/true
-      - -Ddnsmasq=/usr/bin/true
-      - -Dsession_tracking=no
-      - -Dselinux=false
-      - -Dsystemd_journal=false
-      - -Dlibaudit=no
-      - -Dwext=false
-      - -Dwifi=false
-      - -Dppp=false
-      - -Dmodem_manager=false
-      - -Dovs=false
-      - -Dnmcli=false
-      - -Dnmtui=false
-      # We need introspection
-      - -Dintrospection=true
-      - -Dvapi=false
-      - -Ddocs=false
-      - -Dtests=no
-      - -Dfirewalld_zone=false
-      - -Dlibpsl=false
-      - -Dqt=false
-    cleanup:
-      - /sbin
-      - /etc
-      - /include
-      - /lib/pkgconfig
-      - /libexec
-      - /var
-      - /share/bash-completion
-      - /share/doc
-    sources:
-      - type: git
-        url: https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git
-        tag: 1.40.18
-        commit: 2db3748ec8162ce948ba52f71b42a258ff8d64ba
-        x-checker-data:
-          type: anitya
-          project-id: 21197
-          stable-only: true
-          tag-template: $version
-          versions:
-            # Breaking change in 1.42.x: `dns` will be replaced by `dns-data`, which is incompatible with older NetworkManager on the host system
-            <: 1.42.0
+- name: NetworkManager
+  buildsystem: meson
+  build-options:
+    cflags: -ltinfo
+    cxxflags: -ltinfo
+  config-opts:
+  - -Dsystemdsystemunitdir=no
+  - -Ddbus_conf_dir=/app/etc/dbus-1/system.d
+  - -Diptables=/usr/bin/true
+  - -Ddnsmasq=/usr/bin/true
+  - -Dsession_tracking=no
+  - -Dselinux=false
+  - -Dsystemd_journal=false
+  - -Dlibaudit=no
+  - -Dwext=false
+  - -Dwifi=false
+  - -Dppp=false
+  - -Dmodem_manager=false
+  - -Dovs=false
+  - -Dnmcli=false
+  - -Dnmtui=false
+  # We need introspection
+  - -Dintrospection=true
+  - -Dvapi=false
+  - -Ddocs=false
+  - -Dtests=no
+  - -Dfirewalld_zone=false
+  - -Dlibpsl=false
+  - -Dqt=false
+  cleanup:
+  - /sbin
+  - /etc
+  - /include
+  - /lib/pkgconfig
+  - /libexec
+  - /var
+  - /share/bash-completion
+  - /share/doc
+  sources:
+  - type: git
+    url: https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git
+    tag: 1.40.18
+    commit: 2db3748ec8162ce948ba52f71b42a258ff8d64ba
+    x-checker-data:
+      type: anitya
+      project-id: 21197
+      stable-only: true
+      tag-template: $version
+      versions:
+        # Breaking change in 1.42.x: `dns` will be replaced by `dns-data`, which is incompatible with older NetworkManager on the host system
+        <: 1.42.0
 
-      # To fix `Support for given configuration is not implemented` when trying to connect: https://github.com/flathub/com.protonvpn.www/issues/2
-      # Copied from https://github.com/flathub/com.github.jkotra.eovpn/blob/670f19e2aee1c9559fbe4eed904e35500843ae88/0001-disable-ownership-check-for-plugins.patch
-      - type: patch
-        path: patches/NetworkManager/disable-ownership-check-for-plugins.patch
+  # To fix `Support for given configuration is not implemented` when trying to connect: https://github.com/flathub/com.protonvpn.www/issues/2
+  # Copied from https://github.com/flathub/com.github.jkotra.eovpn/blob/670f19e2aee1c9559fbe4eed904e35500843ae88/0001-disable-ownership-check-for-plugins.patch
+  - type: patch
+    path: patches/NetworkManager/disable-ownership-check-for-plugins.patch
 
   # https://github.com/flathub/com.github.jkotra.eovpn/blob/670f19e2aee1c9559fbe4eed904e35500843ae88/com.github.jkotra.eovpn.yml#L133C17-L151
 - name: libnma

--- a/com.protonvpn.www.yml
+++ b/com.protonvpn.www.yml
@@ -239,8 +239,8 @@ modules:
   sources:
   - type: git
     url: https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git
-    tag: 1.56.1
-    commit: b829f838fc5d8c93437faa5db44a5396b67893de # Breaking change in 1.42.x: `dns` will be replaced by `dns-data`, which is incompatible with older NetworkManager on the host system
+    tag: 1.40.18
+    commit: 2db3748ec8162ce948ba52f71b42a258ff8d64ba
   - type: patch
     path: patches/NetworkManager/disable-ownership-check-for-plugins.patch
 


### PR DESCRIPTION
Updated NetworkManager source tag and commit to version 1.40.18.

Fixes #468 #469 