### PR TITLE
feat(updater): ignore NetworkManager and its dependencies in tracked modules

### DIFF
--- a/.fedora-tracked-modules.yaml
+++ b/.fedora-tracked-modules.yaml
@@ -4,11 +4,13 @@ modules:
     fedora_package: NetworkManager
     repo_url: https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git
     tag_template: $version
+    ignored: true
   NetworkManager-openvpn:
     recipe: git
     fedora_package: NetworkManager-openvpn
     repo_url: https://github.com/NetworkManager/NetworkManager-openvpn.git
     tag_template: $version
+    ignored: true
   iproute2:
     recipe: archive
     fedora_package: iproute
@@ -22,6 +24,7 @@ modules:
     fedora_package: libnma
     url_template: 
       https://gitlab.gnome.org/GNOME/libnma/-/archive/$version/libnma-$version.tar.gz
+    ignored: true
   meson:
     recipe: pypi
     pypi_name: meson

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/cli.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/cli.py
@@ -78,6 +78,10 @@ def run(
         rows: list[Row] = []
 
         for spec in specs:
+            if spec.ignored:
+                rows.append(Row(spec.name, "skipped", "ignored in mapping config"))
+                continue
+
             try:
                 fedora_version = mdapi.get_version(spec.fedora_package)
             except (PackageNotFoundError, MdapiTransientError) as exc:

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/mapping_loader.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/mapping_loader.py
@@ -44,7 +44,7 @@ def load_mapping(path: Path) -> list[ModuleSpec]:
                 manual_followup=entry.get("manual_followup"),
                 cargo_sources_file=entry.get("cargo_sources_file"),
                 cargo_lock_path=entry.get("cargo_lock_path"),
+                ignored=bool(entry.get("ignored", False)),
             )
         )
     return specs
-

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/migrate.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/migrate.py
@@ -41,6 +41,7 @@ NATIVE_MODULE_HINTS: dict[str, dict] = {
     "libnma": {
         "recipe": "archive",
         "url_template": "https://gitlab.gnome.org/GNOME/libnma/-/archive/$version/libnma-$version.tar.gz",
+        "ignored": True,
     },
     "iproute2": {
         "recipe": "archive",
@@ -55,11 +56,13 @@ NATIVE_MODULE_HINTS: dict[str, dict] = {
         "recipe": "git",
         "repo_url": "https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git",
         "tag_template": "$version",
+        "ignored": True,
     },
     "NetworkManager-openvpn": {
         "recipe": "git",
         "repo_url": "https://github.com/NetworkManager/NetworkManager-openvpn.git",
         "tag_template": "$version",
+        "ignored": True,
     },
     "systemd": {
         "recipe": "git",

--- a/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/models.py
+++ b/scripts/fedora_flatpak_updater/src/fedora_flatpak_updater/models.py
@@ -28,4 +28,6 @@ class ModuleSpec:
     manual_followup: str | None = None
     cargo_sources_file: str | None = None
     cargo_lock_path: str | None = None
+    ignored: bool = False
+
 

--- a/tests/fedora_flatpak_updater/test_cli.py
+++ b/tests/fedora_flatpak_updater/test_cli.py
@@ -88,6 +88,31 @@ def test_run_reports_updated_and_skipped_modules(monkeypatch, manifest_root, map
     assert statuses["python3-nonexistent"] == "skipped"
 
 
+def test_run_skips_ignored_modules(monkeypatch, manifest_root, tmp_path):
+    _patch_common(monkeypatch)
+    mapping_file = tmp_path / ".fedora-tracked-modules.yaml"
+    mapping_file.write_text(
+        """
+modules:
+  python3-idna:
+    fedora_package: python3-idna
+    recipe: pypi
+    pypi_name: idna
+  NetworkManager:
+    fedora_package: NetworkManager
+    recipe: git
+    repo_url: "https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git"
+    tag_template: "$version"
+    ignored: true
+"""
+    )
+    rows = cli.run(mapping_file, manifest_root, dry_run=True)
+    statuses = {row.module_name: (row.status, row.detail) for row in rows}
+    assert statuses["NetworkManager"] == ("skipped", "ignored in mapping config")
+    assert statuses["python3-idna"][0] == "updated"
+
+
+
 def test_dry_run_does_not_write_files(monkeypatch, manifest_root, mapping_file):
     _patch_common(monkeypatch)
     original_text = manifest_root.read_text()

--- a/tests/fedora_flatpak_updater/test_mapping_loader.py
+++ b/tests/fedora_flatpak_updater/test_mapping_loader.py
@@ -104,3 +104,22 @@ modules:
     assert specs[0].cargo_lock_path == "src/_bcrypt/Cargo.lock"
 
 
+def test_load_mapping_parses_ignored_field(tmp_path: Path):
+    yaml_content = """
+modules:
+  NetworkManager:
+    recipe: git
+    fedora_package: NetworkManager
+    repo_url: "https://gitlab.freedesktop.org/NetworkManager/NetworkManager.git"
+    tag_template: "$version"
+    ignored: true
+"""
+    mapping_file = tmp_path / "mapping.yaml"
+    mapping_file.write_text(yaml_content)
+    specs = load_mapping(mapping_file)
+    assert len(specs) == 1
+    assert specs[0].name == "NetworkManager"
+    assert specs[0].ignored is True
+
+
+


### PR DESCRIPTION
### Summary of Changes
- **Data Model & Loader**: Added `ignored: bool = False` attribute to `ModuleSpec` in `models.py` and updated `load_mapping` in `mapping_loader.py` to parse `ignored` from configuration mappings.
- **CLI Guard**: Added an early check for `spec.ignored` in `cli.py` to skip processing ignored dependencies, recording status `"skipped"` and detail `"ignored in mapping config"`.
- **Configuration & Hints**: Marked `NetworkManager`, `NetworkManager-openvpn`, and `libnma` as `ignored: true` in `.fedora-tracked-modules.yaml` and updated `NATIVE_MODULE_HINTS` in `migrate.py`.
- **Tests**: Added unit tests in `test_mapping_loader.py` and `test_cli.py` to verify configuration parsing and execution skipping behavior.

### Rationale
NetworkManager 1.42.x+ introduces breaking changes to DNS configuration options (`dns` replaced by `dns-data`) which cause runtime connectivity failures on host systems with older NetworkManager versions. Marking NetworkManager and its dependencies as `ignored: true` prevents automated pipeline updates from upgrading NetworkManager past `1.40.18`.