### PR TITLE
fix: update proton-vpn-cli to 1.0.3 and add x-checker-data

### DIFF
--- a/com.protonvpn.www.yml
+++ b/com.protonvpn.www.yml
@@ -658,14 +658,18 @@ modules:
         --prefix=${FLATPAK_DEST} "." --no-build-isolation
     modules:
       # flatpak-pip-generator --checker-data --yaml --runtime='org.gnome.Sdk//49' "click" "dbus-fast" "tabulate" -o pip-resources.proton-vpn-cli
-      # https://github.com/ProtonVPN/proton-vpn-cli/blob/f00eb2a07e810f9563323bd38ee4a7bd3c3226c8/setup.py#L16-L23
+      # https://github.com/ProtonVPN/proton-vpn-cli/blob/a7c7abc8d3777f33b8d4c82279bd621258bd810d/setup.py#L25-L33
       - pip-resources.proton-vpn-cli.yaml
     sources:
       - type: git
         url: https://github.com/ProtonVPN/proton-vpn-cli.git
-        tag: v1.0.0
-        commit: f00eb2a07e810f9563323bd38ee4a7bd3c3226c8
+        tag: v1.0.3
+        commit: a7c7abc8d3777f33b8d4c82279bd621258bd810d
         disable-submodules: true
+        x-checker-data:
+          type: anitya
+          project-id: 387797
+          tag-template: v$version
 
   - name: proton-vpn-gtk-app
     buildsystem: simple


### PR DESCRIPTION
### Summary

- Update `proton-vpn-cli` from `v1.0.0` to `v1.0.3` (commit `a7c7abc8d3777f33b8d4c82279bd621258bd810d`).
- Add `x-checker-data` with Anitya project ID `387797` (`type: anitya`, `tag-template: v$version`) so automated Flatpak dependency checkers track future `proton-vpn-cli` releases.

### Rationale & Fix

In `python-proton-vpn-api-core >= 5.5.0`, `connection.py` was refactored into `vpnconnector.py`.
`proton-vpn-cli v1.0.0` was still importing from `proton.vpn.core.connection`, causing `protonvpn` CLI invocations inside the Flatpak to fail immediately with:
```text
ModuleNotFoundError: No module named 'proton.vpn.core.connection'
```
Upstream `proton-vpn-cli v1.0.3` updates the import to `proton.vpn.core.vpnconnector`.

Closes #484.