### PR TITLE
feat: add platform cargo generator, skill runbooks, and triage docs

### DIFF
--- a/.agents/skills/creating-flatpaks/SKILL.md
+++ b/.agents/skills/creating-flatpaks/SKILL.md
@@ -1,0 +1,485 @@
+---
+name: creating-flatpaks
+description: >-
+  Authoring, maintaining, and debugging Flatpak packages (YAML/JSON) for Flathub,
+  including offline Rust/Cargo and Python/pip vendoring, Git submodules, SDK extensions,
+  and build validation.
+---
+
+# Creating and Maintaining Flatpak Packages for Flathub
+
+This skill provides an end-to-end engineering runbook and technical reference for packaging, building, vendoring, debugging, and maintaining sandboxed desktop applications and CLI utilities for Flatpak and Flathub.
+
+---
+
+## 1. Overview & Core Philosophy
+
+Flatpak provides an isolated, sandboxed application runtime across Linux distributions. Building applications for Flathub requires strict adherence to container isolation, deterministic offline compilation, and the principle of least privilege.
+
+```
++-------------------------------------------------------------------------------+
+| 1. DOWNLOAD PHASE (Online / Host Network)                                     |
+|    - Parse manifest and sub-manifests (pip-resources.*.yaml, cargo-sources.json)|
+|    - Fetch all source archives, git repositories, PyPI wheels, and crates     |
+|    - Cryptographically verify sha256 checksums                                |
++-------------------------------------------------------------------------------+
+                                        |
+                                        v
++-------------------------------------------------------------------------------+
+| 2. BUILD PHASE (Offline / Network Namespace Unshared: NO NETWORK)             |
+|    - Mount base SDK (e.g., org.gnome.Sdk//50) and active SDK extensions        |
+|    - Build modules sequentially (/run/build/<module-name>)                    |
+|    - Install compiled binaries and assets to /app (${FLATPAK_DEST})           |
++-------------------------------------------------------------------------------+
+                                        |
+                                        v
++-------------------------------------------------------------------------------+
+| 3. SANDBOXED RUNTIME (Host Isolation & Least Privilege)                       |
+|    - Runtime mount (e.g., org.gnome.Platform//50) + /app filesystem           |
+|    - Bubblewrap container with scoped finish-args (Wayland, D-Bus, Portals)   |
++-------------------------------------------------------------------------------+
+```
+
+### Core Packaging Pillars
+
+1. **Deterministic Offline Builds**: Flathub build workers unshare the network namespace during compilation (`--unshare=network`). All source code, libraries, PyPI packages, and Cargo crates must be declared ahead of time with SHA256 checksums and vendored locally.
+2. **Strict Sandboxing & Least Privilege**: Manifest `finish-args` must grant only the minimal permissions required for operation. Prefer modern XDG Desktop Portals over raw filesystem or unrestricted D-Bus access.
+3. **Modular Manifest Design**: Decompose complex manifests into modular sub-manifests (`pip-resources.*.yaml`, `*-cargo-sources.json`) to keep specifications maintainable and compatible with automated updaters.
+4. **SDK Extension Management**: Toolchains not bundled in the base SDK (e.g., specific Rust compiler versions, LLVM/Clang toolchains) must be mounted via `sdk-extensions` and activated per module.
+
+---
+
+## 2. Progressive Deep-Dive References
+
+For detailed technical specifications, architecture diagrams, and specialized recipes, consult the dedicated reference documents:
+
+- **[Manifest Architecture, SDK Extensions & Permissions Guide](references/manifest-structure-and-permissions.md)**:
+  Full specification of manifest schemas (YAML vs JSON), `sdk-extensions` mounting, deep dive into container isolation flags (`finish-args`), D-Bus filtering, XDG Portals, and Flathub review standards.
+- **[Cargo / Rust Offline Dependency Generation](references/cargo-offline-generation.md)**:
+  Comprehensive guide for packaging standalone Rust apps and native extensions, running `flatpak-cargo-generator.py`, lockfile preparation, cargo config overrides, and offline crate vendoring.
+- **[Python / Pip Offline Dependency Management](references/python-pip-offline.md)**:
+  End-to-end blueprint for Python packaging with `flatpak-pip-generator`, modular `pip-resources.*.yaml` splitting, PyPI metadata tracking (`x-checker-data`), C/Rust native extensions (PyO3/Maturin), and wheel compilation.
+
+---
+
+## 3. End-to-End Packaging Runbook
+
+Follow these structured steps when creating a new Flatpak package or maintaining an existing Flathub repository.
+
+```
++---------------------------------------------------------------------------------+
+| STEP 1: Manifest Initialization & SDK Selection                                 |
+|         Choose Runtime/SDK (GNOME/Freedesktop/KDE) and configure base permissions|
++---------------------------------------------------------------------------------+
+                                        |
+                                        v
++---------------------------------------------------------------------------------+
+| STEP 2: Generate Offline Dependencies                                           |
+|         Run flatpak-cargo-generator.py and/or flatpak-pip-generator             |
++---------------------------------------------------------------------------------+
+                                        |
+                                        v
++---------------------------------------------------------------------------------+
+| STEP 3: Configure Git Submodules, Nested Sources & Patches                      |
+|         Structure source trees using 'dest' and manage local patches            |
++---------------------------------------------------------------------------------+
+                                        |
+                                        v
++---------------------------------------------------------------------------------+
+| STEP 4: Build Hybrid & Native Stacks                                            |
+|         Wire PyO3/Maturin, C/Meson, and CMake native module dependencies        |
++---------------------------------------------------------------------------------+
+                                        |
+                                        v
++---------------------------------------------------------------------------------+
+| STEP 5: Local Build, Test & Interactive Debugging                               |
+|         Execute flatpak-builder, inspect container, verify CLI & GUI            |
++---------------------------------------------------------------------------------+
+                                        |
+                                        v
++---------------------------------------------------------------------------------+
+| STEP 6: Flathub Quality Linting & Upstream Maintenance                          |
+|         Validate AppStream metainfo, run flatpak-builder-lint, configure checks |
++---------------------------------------------------------------------------------+
+```
+
+---
+
+### Step 1: Manifest Initialization & SDK Selection
+
+1. **Choose Base Runtime & SDK**:
+   - **GNOME Platform** (`org.gnome.Platform` / `org.gnome.Sdk`): GTK3, GTK4, Libadwaita, Python PyGObject, GStreamer applications.
+   - **Freedesktop Platform** (`org.freedesktop.Platform` / `org.freedesktop.Sdk`): Generic Linux apps, Electron, Qt/raw X11, CLI tools.
+   - **KDE Platform** (`org.kde.Platform` / `org.kde.Sdk`): Qt5, Qt6, KDE Frameworks applications.
+
+2. **Define Base Skeleton**:
+   Create `<app-id>.yml` (e.g., `com.example.App.yml`) with schema header:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/flatpak/flatpak-builder/main/data/flatpak-manifest.schema.json
+app-id: com.example.App
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: app-binary
+
+# Toolchain extensions (Rust, LLVM, etc.)
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-stable
+
+finish-args:
+  # Display & IPC
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  # Networking (if required)
+  - --share=network
+  # Audio (if required)
+  - --socket=pulseaudio
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share/pkgconfig
+  - /share/aclocal
+  - /man
+  - /share/man
+  - '*.la'
+  - '*.a'
+
+modules: []
+```
+
+> [!TIP]
+> For complete permission flag references and security review rules, see [references/manifest-structure-and-permissions.md](references/manifest-structure-and-permissions.md).
+
+---
+
+### Step 2: Generating Offline Dependencies
+
+#### 2.1 Rust / Cargo Dependencies
+When an application or Python C-extension relies on Rust crates:
+
+1. **Obtain or Generate `Cargo.lock`**:
+   If upstream does not ship `Cargo.lock` in the tarball, generate it locally from `Cargo.toml`:
+   ```bash
+   cargo generate-lockfile --manifest-path Cargo.toml
+   ```
+
+2. **Generate `cargo-sources.json`**:
+   Use `flatpak-cargo-generator.py` from `flatpak-builder-tools`:
+   ```bash
+   python3 /path/to/flatpak-cargo-generator.py Cargo.lock -o cargo-sources.json
+   ```
+
+3. **Wire Cargo Sources into Module**:
+   ```yaml
+   modules:
+     - name: rust-component
+       buildsystem: simple
+       build-options:
+         append-path: /usr/lib/sdk/rust-stable/bin
+         env:
+           CARGO_HOME: /run/build/rust-component/cargo
+           CARGO_NET_OFFLINE: 'true'
+       build-commands:
+         - cargo --offline fetch --manifest-path Cargo.toml --verbose
+         - cargo --offline build --release --verbose
+         - install -Dm755 target/release/app-binary /app/bin/app-binary
+       sources:
+         - type: git
+           url: https://github.com/example/app.git
+           tag: v1.0.0
+           commit: 0123456789abcdef0123456789abcdef01234567
+         - cargo-sources.json
+   ```
+
+> [!NOTE]
+> For detailed instructions on Git dependencies, cargo configs, and workspace configurations, consult [references/cargo-offline-generation.md](references/cargo-offline-generation.md).
+
+#### 2.2 Python / Pip Dependencies
+When packaging Python applications or native Python extensions:
+
+1. **Generate Resource Files**:
+   Use `flatpak-pip-generator` to create YAML source blocks with `x-checker-data` automation:
+   ```bash
+   flatpak-pip-generator --checker-data --yaml --runtime='org.gnome.Sdk//50' \
+     click dbus-fast tabulate -o pip-resources.my-module
+   ```
+
+2. **Split Monolithic Dependency Trees**:
+   Divide large dependency graphs into domain-specific sub-manifests (e.g., `pip-resources.api-core.yaml`, `pip-resources.gui.yaml`).
+
+3. **Install Offline with Pip**:
+   ```yaml
+   modules:
+     - name: python-dependencies
+       buildsystem: simple
+       build-commands:
+         - pip3 install --verbose --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} --no-build-isolation .
+       sources:
+         - pip-resources.my-module.yaml
+   ```
+
+> [!IMPORTANT]
+> Always pass `--no-build-isolation` to `pip3 install`. In an offline sandbox, pip build isolation will attempt to create a temporary virtual environment and fetch build dependencies from PyPI, which fails immediately. See [references/python-pip-offline.md](references/python-pip-offline.md).
+
+---
+
+### Step 3: Handling Git Submodules & Nested Sources
+
+When upstream repositories use submodules, vendored components, or custom patches:
+
+```yaml
+sources:
+  # Primary repository
+  - type: git
+    url: https://github.com/example/main-repo.git
+    tag: v2.4.0
+    commit: abc1234def567890abcdef1234567890abcdef12
+
+  # Submodule checked out into specific destination directory
+  - type: git
+    url: https://github.com/example/submodule-dep.git
+    tag: v1.2.0
+    commit: fedcba0987654321fedcba0987654321fedcba09
+    dest: subprojects/submodule-dep
+
+  # Custom patch to fix build paths or runtime behaviors
+  - type: patch
+    path: patches/fix-hardcoded-paths.patch
+
+  # Desktop launcher or wrapper script
+  - type: file
+    path: com.example.App.desktop
+
+  # AppStream metainfo
+  - type: file
+    path: com.example.App.metainfo.xml
+```
+
+---
+
+### Step 4: Building Hybrid & Native Stacks
+
+#### 4.1 Hybrid Python + Rust Extensions (PyO3 / Maturin / `setuptools-rust`)
+Modules like `python3-bcrypt` or `python3-cryptography` require both Python build headers and the Rust toolchain:
+
+```yaml
+- name: python3-bcrypt
+  buildsystem: simple
+  build-options:
+    append-path: /usr/lib/sdk/rust-stable/bin
+    env:
+      CARGO_HOME: /run/build/python3-bcrypt/cargo
+      CARGO_NET_OFFLINE: 'true'
+      PYO3_OFFLINE: '1'
+  build-commands:
+    - pip3 install --verbose --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} --no-build-isolation .
+  sources:
+    - type: archive
+      url: https://files.pythonhosted.org/packages/.../bcrypt-4.3.0.tar.gz
+      sha256: 0123456789abcdef...
+      x-checker-data:
+        type: pypi
+        name: bcrypt
+    - bcrypt-cargo-sources.json
+```
+
+#### 4.2 Native C / Meson / CMake Modules
+Build supporting native C/C++ libraries prior to the main application:
+
+```yaml
+- name: libndp
+  buildsystem: autotools
+  config-opts:
+    - --disable-static
+    - --enable-shared
+  sources:
+    - type: archive
+      url: http://libndp.org/files/libndp-1.9.tar.gz
+      sha256: 1234567890abcdef...
+      x-checker-data:
+        type: anitya
+        project-id: 13083
+        url-template: http://libndp.org/files/libndp-$version.tar.gz
+```
+
+---
+
+### Step 5: Local Build, Test, & Debugging
+
+#### 5.1 Clean Build & Incremental Iteration
+```bash
+# Full clean build into local directory
+flatpak-builder --force-clean build-dir com.example.App.yml
+
+# Build up to a specific module for rapid debugging
+flatpak-builder --keep-build-dirs --stop-at=target-module build-dir com.example.App.yml
+```
+
+#### 5.2 Local Installation & Execution
+```bash
+# Build and install directly to local user scope
+flatpak-builder --force-clean --user --install build-dir com.example.App.yml
+
+# Launch application
+flatpak run com.example.App
+
+# Pass CLI parameters or subcommands
+flatpak run com.example.App status --verbose
+```
+
+#### 5.3 Interactive Debugging Inside the Container
+When build steps fail or runtime permission errors occur:
+
+```bash
+# 1. Shell into the build container at the exact failure state
+flatpak-builder --run build-dir com.example.App.yml sh
+
+# Inside the build container:
+$ cd /run/build/target-module
+$ echo $PATH
+$ pkg-config --cflags --libs libndp
+$ cargo build --verbose
+
+# 2. Shell into the installed runtime sandbox (with SDK debug tools)
+flatpak run --command=sh --devel com.example.App
+
+# Inside the runtime sandbox:
+$ ls -la /app/bin /app/lib/python3.12/site-packages
+$ busctl --user list | grep -E 'secrets|portal'
+```
+
+#### 5.4 Diagnostic Environment Flags
+```bash
+# Trace GIO and GTK debug messages
+G_MESSAGES_DEBUG=all flatpak run com.example.App
+
+# Trace Wayland display events
+WAYLAND_DEBUG=1 flatpak run com.example.App
+
+# Trace Secret Service / Keyring interactions
+G_MESSAGES_DEBUG=all SECRET_DEBUG=1 flatpak run com.example.App
+```
+
+---
+
+### Step 6: Flathub Quality, Linting & Upstream Maintenance
+
+#### 6.1 AppStream Metadata Validation
+Flathub requires valid AppStream metainfo placed in `/app/share/metainfo/<app-id>.metainfo.xml`:
+
+```bash
+# Validate metainfo file without internet access
+appstream-util validate --nonet com.example.App.metainfo.xml
+appstreamcli validate --no-net com.example.App.metainfo.xml
+```
+
+Ensure the metainfo includes:
+- `<id>com.example.App</id>` matching manifest `app-id`.
+- Valid `<name>`, `<summary>`, `<description>` with clean paragraphs.
+- `<metadata_license>CC0-1.0</metadata_license>` or `FSFAP`.
+- `<project_license>` specifying the application license.
+- `<launchable type="desktop-id">com.example.App.desktop</launchable>`.
+- `<releases>` containing at least the latest release tag and date.
+- `<screenshots>` with 16:9 images hosted on public HTTPS URLs.
+
+#### 6.2 Manifest & Repo Linting
+Run `flatpak-builder-lint` to catch Flathub submission policy violations:
+
+```bash
+# Lint manifest
+flatpak-builder-lint manifest com.example.App.yml
+
+# Lint AppStream file
+flatpak-builder-lint appstream com.example.App.metainfo.xml
+
+# Lint built repository build directory
+flatpak-builder-lint repo build-dir
+```
+
+#### 6.3 Automated Dependency Tracking
+Flathub's build system runs [Flatpak-External-Data-Checker](https://github.com/flathub/flatpak-external-data-checker) to monitor and open pull requests for new upstream releases:
+
+```yaml
+sources:
+  - type: archive
+    url: https://github.com/example/app/archive/v1.5.0.tar.gz
+    sha256: 0123456789abcdef...
+    x-checker-data:
+      type: json
+      url: https://api.github.com/repos/example/app/releases/latest
+      version-query: .tag_name | sub("^v"; "")
+      url-query: '"https://github.com/example/app/archive/v" + $version + ".tar.gz"'
+```
+
+---
+
+## 4. Quick Reference Cheatsheets
+
+### Common CLI Commands
+
+| Action | Command |
+| :--- | :--- |
+| **Clean Build** | `flatpak-builder --force-clean build-dir <manifest.yml>` |
+| **User Install** | `flatpak-builder --force-clean --user --install build-dir <manifest.yml>` |
+| **Incremental Stop** | `flatpak-builder --keep-build-dirs --stop-at=<module> build-dir <manifest.yml>` |
+| **Build Shell** | `flatpak-builder --run build-dir <manifest.yml> sh` |
+| **Runtime Shell** | `flatpak run --command=sh --devel <app-id>` |
+| **Override Permission**| `flatpak run --socket=session-bus <app-id>` |
+| **Show Permissions** | `flatpak info --show-permissions <app-id>` |
+| **Show Dependencies** | `flatpak-builder --show-deps <manifest.yml>` |
+| **Generate Cargo** | `python3 flatpak-cargo-generator.py Cargo.lock -o cargo-sources.json` |
+| **Generate Pip** | `flatpak-pip-generator --checker-data --yaml --runtime='org.gnome.Sdk//50' <pkgs>` |
+| **Lint Manifest** | `flatpak-builder-lint manifest <manifest.yml>` |
+| **Validate Metainfo**| `appstreamcli validate --no-net <metainfo.xml>` |
+
+---
+
+### Essential `finish-args` Matrix
+
+| Permission Category | Argument | Purpose / Flathub Review Guidance |
+| :--- | :--- | :--- |
+| **Display** | `--socket=wayland` | Native Wayland display socket (preferred). |
+| | `--socket=fallback-x11` | X11 display socket fallback for legacy sessions. |
+| | `--share=ipc` | Shared memory IPC (required for X11 shared memory buffers). |
+| **Networking** | `--share=network` | Outbound and inbound internet connectivity. |
+| **Audio** | `--socket=pulseaudio` | Audio playback and capture via PulseAudio/PipeWire. |
+| **Filesystems** | `xdg-download` | Access to `~/Downloads` (read/write). |
+| | `xdg-config/app:create` | Access to `~/.config/app`, creating directory if missing. |
+| | `~/.cert:create` | Access to custom certificate directories. |
+| | `/var/log/journal:ro` | Read-only access to host systemd journal for diagnostic logs. |
+| **Session D-Bus** | `--talk-name=org.freedesktop.secrets` | Secret Service credential storage (GNOME Keyring/KWallet). |
+| | `--talk-name=org.kde.StatusNotifierWatcher` | System tray icon notification area integration. |
+| **System D-Bus** | `--system-talk-name=org.freedesktop.NetworkManager` | Monitor & control host network connections via NetworkManager. |
+| | `--system-talk-name=org.freedesktop.login1` | Monitor system sleep/resume/shutdown states via logind. |
+| **Devices** | `--device=dri` | GPU hardware acceleration (OpenGL / Vulkan). |
+| | `--device=all` | Full `/dev` access (requires Flathub justification; e.g. FIDO2 keys). |
+
+---
+
+### Build Environment & Toolchain Variables
+
+| Variable | Recommended Value | Context & Purpose |
+| :--- | :--- | :--- |
+| `CARGO_HOME` | `/run/build/<module>/cargo` | Isolates cargo state directory to current build container. |
+| `CARGO_NET_OFFLINE` | `'true'` | Strictly enforces offline crate compilation. |
+| `PYO3_OFFLINE` | `'1'` | Forces PyO3 native build scripts to avoid querying remote metadata. |
+| `PIP_NO_INDEX` | `'true'` | Ensures pip refuses remote network queries. |
+| `PIP_FIND_LINKS` | `'file://${PWD}'` | Instructs pip to resolve all wheels/sdists from working directory. |
+| `PKG_CONFIG_PATH` | `/app/lib/pkgconfig:/app/share/pkgconfig:...` | Ensures compiler discovers installed `/app` native libraries. |
+| `PYTHONPATH` | `/app/lib/python3.12/site-packages` | Ensures Python scripts can discover modules installed into `/app`. |
+
+---
+
+### Common Build Failures & Resolution Matrix
+
+| Symptom / Error Message | Root Cause | Actionable Fix |
+| :--- | :--- | :--- |
+| `error: net: network unreachable` during `cargo build` | Cargo attempted to download an un-vendored crate. | Run `flatpak-cargo-generator.py` on the complete `Cargo.lock` and include `cargo-sources.json` in `sources`. |
+| `ERROR: Could not find a version that satisfies the requirement` | Pip tried to fetch a missing dependency or build tool. | Run `flatpak-pip-generator` to include all transitive dependencies; pass `--no-build-isolation` to `pip3 install`. |
+| `rustc: command not found` | Rust toolchain extension not mounted or not in `PATH`. | Add `org.freedesktop.Sdk.Extension.rust-stable` to `sdk-extensions` and set `append-path: /usr/lib/sdk/rust-stable/bin`. |
+| `Package <name> was not found in pkg-config search path` | C dependency not built or pkg-config path missing. | Add required C library module before target module; verify `/app/lib/pkgconfig` is in `PKG_CONFIG_PATH`. |
+| App crashes on startup with `KeyringLocked` or Secret Service error | Missing Secret Service D-Bus permission in `finish-args`. | Add `--talk-name=org.freedesktop.secrets` to `finish-args`. |
+| App crashes under Wayland compositor | Missing Wayland socket or fallback display permission. | Ensure manifest includes both `--socket=wayland` and `--socket=fallback-x11`. |

--- a/.agents/skills/creating-flatpaks/references/manifest-structure-and-permissions.md
+++ b/.agents/skills/creating-flatpaks/references/manifest-structure-and-permissions.md
@@ -1,0 +1,832 @@
+# Flatpak Manifest Structure, SDK Extensions, and Permissions Reference
+
+This reference guide provides an exhaustive technical specification for designing, structuring, and securing Flatpak manifests for Flathub packages. It details the manifest schema, build lifecycle, SDK extension activation, sandboxing permission architecture (`finish-args`), Flathub security review standards, and production-grade manifest blueprints.
+
+---
+
+## Table of Contents
+1. [Manifest Architecture & Schema Overview](#1-manifest-architecture--schema-overview)
+   - [YAML vs. JSON Format Standards](#11-yaml-vs-json-format-standards)
+   - [Schema Definition & Language Server Integration](#12-schema-definition--language-server-integration)
+   - [Top-Level Properties Reference](#13-top-level-properties-reference)
+   - [Module Specification & Build Systems](#14-module-specification--build-systems)
+   - [Source Types & Properties](#15-source-types--properties)
+2. [SDK Extensions Management](#2-sdk-extensions-management)
+   - [Extension Architecture & Mount Mechanics](#21-extension-architecture--mount-mechanics)
+   - [Declaration in `sdk-extensions`](#22-declaration-in-sdk-extensions)
+   - [Activating Extensions Inside Modules](#23-activating-extensions-inside-modules)
+   - [Multi-Extension Configurations & Runtime Matching](#24-multi-extension-configurations--runtime-matching)
+   - [SDK Extension Cleanup](#25-sdk-extension-cleanup)
+3. [Sandboxing & `finish-args` Deep Dive](#3-sandboxing--finish-args-deep-dive)
+   - [Display & GUI Sockets](#31-display--gui-sockets)
+   - [Audio & Media Sockets](#32-audio--media-sockets)
+   - [Peripheral & IPC Sockets](#33-peripheral--ipc-sockets)
+   - [Filesystem Permissions & Modifiers](#34-filesystem-permissions--modifiers)
+   - [D-Bus Mediation (Session & System Bus)](#35-d-bus-mediation-session--system-bus)
+   - [Device & Subsystem Access](#36-device--subsystem-access)
+4. [Flathub Quality Standards & Least Privilege](#4-flathub-quality-standards--least-privilege)
+   - [The Principle of Least Privilege & XDG Portals](#41-the-principle-of-least-privilege--xdg-portals)
+   - [Flathub Sensitive Permission Policy & Justifications](#42-flathub-sensitive-permission-policy--justifications)
+   - [AppStream Metainfo Integration & Validation](#43-appstream-metainfo-integration--validation)
+5. [Real-World Manifest Blueprints & Auditing](#5-real-world-manifest-blueprints--auditing)
+   - [Blueprint 1: GNOME 50 / GTK4 / Libadwaita Desktop App](#51-blueprint-1-gnome-50--gtk4--libadwaita-desktop-app)
+   - [Blueprint 2: System / Network Utility (Proton VPN Architecture)](#52-blueprint-2-system--network-utility-proton-vpn-architecture)
+   - [Permission Auditing & Verification Tooling](#53-permission-auditing--verification-tooling)
+
+---
+
+## 1. Manifest Architecture & Schema Overview
+
+A Flatpak manifest is a declarative build recipe parsed by `flatpak-builder`. It defines the application identifier, base runtime, development SDK, required system permissions, compilation flags, and the ordered tree of modules that comprise the final application payload.
+
+### 1.1 YAML vs. JSON Format Standards
+
+`flatpak-builder` natively supports manifests written in either **YAML** (`.yaml`, `.yml`) or **JSON** (`.json`).
+
+| Feature | YAML Format | JSON Format |
+| :--- | :--- | :--- |
+| **Standard File Extension** | `<app-id>.yml` or `<app-id>.yaml` | `<app-id>.json` |
+| **Comments** | Supported (`# comment`) | Unsupported (requires non-standard hacks) |
+| **Multiline Strings** | Supported (`|`, `>`) | Unsupported (requires `\n` escaping) |
+| **Readability** | High; compact 2-space indentation | Verbose; requires braces and trailing commas |
+| **External File Includes** | Full support (`shared-modules/...`, `pip-resources.*.yaml`) | Full support (`shared-modules/...`) |
+| **Flathub Preference** | **Standard & Recommended** for primary manifests | Recommended for shared sub-modules / cargo lists |
+
+#### Formatting Rules for YAML Manifests:
+- Use consistent **2-space indentation** (do not use tabs).
+- Enforce strings containing version numbers or special characters (e.g. `'50'`, `'24.08'`) as quoted strings to avoid YAML type coercion to numbers or dates.
+- Keep module names kebab-case or lower-snake-case matching upstream conventions.
+- Retain upstream metadata annotations such as `x-checker-data`.
+
+### 1.2 Schema Definition & Language Server Integration
+
+To enable real-time validation, autocomplete, and error diagnostics in modern editors (VS Code, Neovim, Zed, Emacs), include the Flatpak manifest JSON Schema header on line 1 of the manifest:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/flatpak/flatpak-builder/main/data/flatpak-manifest.schema.json
+
+id: org.example.App
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: app-binary
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+modules: []
+```
+
+### 1.3 Top-Level Properties Reference
+
+The root object of the manifest configures the global build environment, runtime linkages, and execution sandbox.
+
+```
++-----------------------------------------------------------------------------------+
+| Flatpak Manifest (Top-Level)                                                      |
+|                                                                                   |
+|  [Identity]          id: com.protonvpn.www                                        |
+|  [Runtime Stack]     runtime: org.gnome.Platform, runtime-version: '50'           |
+|                      sdk: org.gnome.Sdk                                           |
+|  [SDK Extensions]    sdk-extensions: [ org.freedesktop.Sdk.Extension.rust-stable ]|
+|  [Entrypoint]        command: protonvpn-app                                       |
+|  [Sandbox]           finish-args: [ --socket=wayland, --share=network, ... ]      |
+|  [Global Build Opts] build-options: { cflags: "...", env: { ... } }               |
+|  [Global Cleanup]    cleanup: [ "/include", "*.la", "/lib/pkgconfig" ]            |
+|  [Modules Tree]      modules: [ module-1, module-2, ..., main-app-module ]        |
++-----------------------------------------------------------------------------------+
+```
+
+#### Complete Top-Level Property Reference Table:
+
+| Property | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `id` / `app-id` | `string` | **Yes** | Unique reverse-DNS application ID (e.g., `com.protonvpn.www`, `org.gnome.Calculator`). Must match the desktop file and AppStream metainfo name. |
+| `runtime` | `string` | **Yes** | Application runtime ID (e.g., `org.gnome.Platform`, `org.freedesktop.Platform`, `org.kde.Platform`). |
+| `runtime-version` | `string` | **Yes** | Version branch of the runtime and SDK (e.g., `'50'`, `'24.08'`, `'6.8'`). Must be enclosed in quotes. |
+| `sdk` | `string` | **Yes** | Development SDK matching the runtime (e.g., `org.gnome.Sdk`, `org.freedesktop.Sdk`, `org.kde.Sdk`). |
+| `command` | `string` | **Yes** | Primary executable binary or wrapper script located in `/app/bin/` executed when `flatpak run <id>` is called. |
+| `finish-args` | `array[string]` | **Yes** | Command-line arguments passed to `flatpak build-finish` to define the runtime sandbox boundary and host permissions. |
+| `modules` | `array[object\|string]`| **Yes** | Sequential list of module objects or paths to included module files (`.json` or `.yaml`) built in order. |
+| `sdk-extensions` | `array[string]` | No | List of SDK extension IDs required during build time (e.g., `org.freedesktop.Sdk.Extension.rust-stable`). |
+| `build-options` | `object` | No | Global compiler flags, environment variables, and search path overrides applied to all modules. |
+| `cleanup` | `array[string]` | No | Global filename and path glob patterns removed from `/app` after all modules are built (e.g., header files, static libraries). |
+| `cleanup-commands` | `array[string]` | No | Arbitrary shell commands executed inside the container during final cleanup phase. |
+| `branch` | `string` | No | The Flatpak branch name for the built package (defaults to `stable` on Flathub). |
+| `tags` | `array[string]` | No | Tags describing build metadata (e.g., `["nightly"]`). |
+| `separate-locales` | `boolean` | No | When `true` (default), translations are extracted into a separate `.Locale` extension to reduce base download size. |
+| `copy-icon` | `boolean` | No | When `true`, automatically extracts application icons from the source directories into the exported export root. |
+
+#### Global `build-options` Configuration:
+```yaml
+build-options:
+  cflags: "-O2 -g -fstack-protector-strong"
+  cxxflags: "-O2 -g -fstack-protector-strong"
+  env:
+    V: "1"
+    PYTHONNOUSERSITE: "1"
+  append-path: "/usr/lib/sdk/rust-stable/bin"
+  prepend-path: "/app/bin"
+  append-ld-library-path: "/app/lib"
+  strip: true
+  no-debuginfo: false
+```
+
+---
+
+### 1.4 Module Specification & Build Systems
+
+Modules represent isolated compilation units. They are executed sequentially in the order declared in the manifest. All module artifacts are installed directly into `/app` (`${FLATPAK_DEST}`).
+
+```yaml
+modules:
+  - name: libsodium
+    buildsystem: autotools
+    config-opts:
+      - --disable-static
+      - --enable-shared
+    sources:
+      - type: archive
+        url: https://download.libsodium.org/libsodium/releases/libsodium-1.0.20-RELEASE.tar.gz
+        sha256: ebb60a8be0160204a37b38eb15e523f20f04c644efb4d24174d8ac85474e2d45
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - "*.la"
+```
+
+#### Module Property Reference:
+
+| Property | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `name` | `string` | *Required* | Name of the module. Used for build directories (`/run/build/<name>`) and logs. |
+| `buildsystem` | `string` | `autotools` | Build system driver: `simple`, `meson`, `cmake`, `cmake-ninja`, `autotools`, `qmake`. |
+| `sources` | `array[object]` | `[]` | List of source archives, git repositories, files, or scripts fetched and placed in the build directory. |
+| `config-opts` | `array[string]` | `[]` | Flags passed to the configuration command (e.g., `./configure`, `meson setup`, `cmake`). |
+| `build-commands` | `array[string]` | `[]` | Shell commands executed when `buildsystem: simple` is used, or custom compilation phases. |
+| `post-install` | `array[string]` | `[]` | Shell commands executed immediately after module installation finishes. |
+| `build-options` | `object` | `{}` | Module-scoped overrides for environment variables, compiler flags, and search paths. |
+| `cleanup` | `array[string]` | `[]` | Glob patterns of files to remove from `/app` after this specific module completes. |
+| `ensure-writable`| `array[string]` | `[]` | Files or directories in `/app` made writable during module build steps. |
+| `modules` | `array[object]` | `[]` | Nested sub-modules compiled recursively before the parent module build starts. |
+
+#### Supported `buildsystem` Types:
+
+1. **`simple`**: No automated configure/make/install harness. `flatpak-builder` executes the exact list of shell commands declared in `build-commands`. Essential for Python `pip` installs, binary repackaging, and custom shell scripts.
+2. **`meson`**: Runs `meson setup _flatpak_build --prefix=/app ${config-opts}`, `ninja -C _flatpak_build`, and `ninja -C _flatpak_build install`.
+3. **`cmake` / `cmake-ninja`**: Runs `cmake -B _flatpak_build -DCMAKE_INSTALL_PREFIX:PATH=/app ${config-opts}`, followed by `make` or `ninja` compilation and installation.
+4. **`autotools`**: Runs `./configure --prefix=/app ${config-opts}`, `make -j${FLATPAK_BUILDER_N_JOBS}`, and `make install`.
+5. **`qmake`**: Invokes `qmake PREFIX=/app ${config-opts}`, `make`, and `make install`.
+
+---
+
+### 1.5 Source Types & Properties
+
+Flatpak downloads all sources ahead-of-time during the online download phase, verifying cryptographic hashes.
+
+```yaml
+sources:
+  # 1. Archive Source (tar.gz, tar.xz, tar.bz2, zip)
+  - type: archive
+    url: https://github.com/example/app/releases/download/v1.0.0/app-1.0.0.tar.gz
+    sha256: 3a2c5e...
+    strip-components: 1
+    dest: subfolder-name
+
+  # 2. Git Repository
+  - type: git
+    url: https://github.com/example/libfoo.git
+    tag: v2.1.0
+    commit: e4d909c290d0fb1ca068ffaddf22cbd038f61406
+
+  # 3. Static File / Wheel
+  - type: file
+    url: https://files.pythonhosted.org/packages/.../package-1.0-py3-none-any.whl
+    sha256: d8e20...
+    dest-filename: package-1.0-py3-none-any.whl
+
+  # 4. Inline Script / Shell
+  - type: script
+    commands:
+      - exec python3 /app/lib/python3.12/site-packages/my_app/main.py "$@"
+    dest-filename: my-app-wrapper
+
+  # 5. Patch
+  - type: patch
+    path: fix-hardcoded-paths.patch
+    strip-components: 1
+
+  # 6. Local Directory / File
+  - type: dir
+    path: ../local-source-tree
+
+  # 7. Inline Content
+  - type: inline
+    contents: |
+      [Desktop Entry]
+      Type=Application
+      Name=Custom Tool
+      Exec=custom-tool
+      Icon=com.example.App
+    dest-filename: com.example.App.desktop
+```
+
+#### Source Types Comparison:
+
+| Source Type | Key Properties | Purpose & Usage Notes |
+| :--- | :--- | :--- |
+| `archive` | `url`, `sha256`, `strip-components`, `dest` | Source tarballs and zip archives. Standard for upstream C/C++/Rust libraries. |
+| `git` | `url`, `tag`, `commit`, `branch` | Git repositories. Always pin to an immutable `commit` hash for reproducibility. |
+| `file` | `url`, `sha256`, `dest-filename`, `dest` | Standalone files, Python `.whl` wheels, prebuilt assets. |
+| `script` | `commands`, `dest-filename` | Generates an executable shell script in the build directory. |
+| `inline` | `contents`, `dest-filename` | Generates a static text configuration or desktop entry file. |
+| `patch` | `path` (local) or `url` (remote), `strip-components` | Applies unified diff patches using `patch -p<strip-components>`. |
+| `dir` | `path`, `dest` | Copies local repository directories into the build sandbox. |
+| `extra-data` | `url`, `sha256`, `size`, `filename` | Proprietary/unredistributable binaries downloaded at client install time. |
+
+---
+
+## 2. SDK Extensions Management
+
+Flatpak SDK extensions provide isolated toolchains (Rust, LLVM/Clang, OpenJDK, Go, Vala, Mono) without bloating the base runtime image.
+
+```
+Host Filesystem -> /usr/lib/sdk/<extension-name>/ (Mounted during build)
+                     ├── bin/ (Compilers: rustc, cargo, clang, javac)
+                     ├── lib/ (Libraries, LLVM runtime, Rust stdlib)
+                     └── include/ (Header files)
+```
+
+### 2.1 Extension Architecture & Mount Mechanics
+
+When `flatpak-builder` encounters an entry in `sdk-extensions`, it mounts the extension filesystem from the host into `/usr/lib/sdk/<extension-name>/` inside the build container. SDK extensions are build-time only: they are never included in the exported `/app` runtime unless explicitly copied or referenced.
+
+### 2.2 Declaration in `sdk-extensions`
+
+Declare required extensions at the manifest root under `sdk-extensions`:
+
+```yaml
+id: com.protonvpn.www
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-stable
+  - org.freedesktop.Sdk.Extension.llvm18
+  - org.freedesktop.Sdk.Extension.openjdk21
+```
+
+#### Common SDK Extension Identifiers:
+
+| Extension Identifier | Contained Toolchains | Primary Use Cases |
+| :--- | :--- | :--- |
+| `org.freedesktop.Sdk.Extension.rust-stable` | `rustc`, `cargo`, `rust-std` | Rust applications, PyO3/maturin/setuptools-rust native modules. |
+| `org.freedesktop.Sdk.Extension.llvm18` | `clang`, `clang++`, `llvm-config`, `lld` | Modern C++20 builds, Clang plugins, Rust bindgen. |
+| `org.freedesktop.Sdk.Extension.openjdk21` | `javac`, `java`, `jar`, Maven/Gradle | Java desktop applications and build tools. |
+| `org.freedesktop.Sdk.Extension.golang` | `go`, Go toolchain | Go applications and utilities. |
+| `org.freedesktop.Sdk.Extension.vala-extra` | `valac`, Vala bindings | Advanced Vala / GObject development. |
+| `org.freedesktop.Sdk.Extension.node20` | `node`, `npm`, `yarn` | Electron / Node.js web asset builds. |
+
+---
+
+### 2.3 Activating Extensions Inside Modules
+
+Declaring an extension in `sdk-extensions` only mounts it into `/usr/lib/sdk/<extension>/`. To make compilers and libraries visible during compilation, configure module-level `build-options`:
+
+```yaml
+modules:
+  - name: python3-bcrypt
+    buildsystem: simple
+    build-options:
+      # Prepend or append the extension binaries to PATH
+      append-path: /usr/lib/sdk/rust-stable/bin
+      env:
+        CARGO_HOME: /run/build/python3-bcrypt/cargo-home
+        RUSTUP_HOME: /run/build/python3-bcrypt/rustup-home
+        # Set LLVM / Clang environment if needed
+        CC: /usr/lib/sdk/llvm18/bin/clang
+        CXX: /usr/lib/sdk/llvm18/bin/clang++
+        PKG_CONFIG_PATH: /app/lib/pkgconfig:/usr/lib/pkgconfig:/usr/lib/sdk/llvm18/lib/pkgconfig
+    build-commands:
+      - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} . --no-build-isolation
+    sources:
+      - type: archive
+        url: https://files.pythonhosted.org/packages/.../bcrypt-4.3.0.tar.gz
+        sha256: 4b297...
+```
+
+#### Key `build-options` for SDK Extension Control:
+- `append-path` / `prepend-path`: Injects `/usr/lib/sdk/<extension>/bin` into the shell `$PATH`.
+- `append-ld-library-path` / `prepend-ld-library-path`: Injects `/usr/lib/sdk/<extension>/lib` into dynamic linker search paths.
+- `append-pkg-config-path`: Adds extension `.pc` files to `$PKG_CONFIG_PATH`.
+- `env`: Exports necessary environment variables such as `JAVA_HOME: /usr/lib/sdk/openjdk21/jvm/openjdk-21` or `CARGO_HOME`.
+
+---
+
+### 2.4 Multi-Extension Configurations & Runtime Matching
+
+When combining multiple SDK extensions (e.g., Rust + LLVM + OpenJDK):
+
+```yaml
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-stable
+  - org.freedesktop.Sdk.Extension.llvm18
+
+modules:
+  - name: native-hybrid-module
+    buildsystem: meson
+    build-options:
+      append-path: /usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm18/bin
+      append-ld-library-path: /usr/lib/sdk/llvm18/lib
+      env:
+        CC: /usr/lib/sdk/llvm18/bin/clang
+        CXX: /usr/lib/sdk/llvm18/bin/clang++
+        LIBCLANG_PATH: /usr/lib/sdk/llvm18/lib
+```
+
+> [!IMPORTANT]
+> **Runtime Branch Matching**: SDK extensions must match the base runtime version branch. If `runtime-version: '50'` (GNOME 50 based on Freedesktop 24.08), `flatpak-builder` automatically requests the `50` or `24.08` branch of `org.freedesktop.Sdk.Extension.*`.
+
+### 2.5 SDK Extension Cleanup
+
+Because SDK extensions are mounted into `/usr/lib/sdk/` during the build container lifecycle, they are automatically detached when `flatpak-builder` packages the application. They leave zero footprint in the final `/app` directory unless files were explicitly copied into `/app`.
+
+---
+
+## 3. Sandboxing & `finish-args` Deep Dive
+
+The `finish-args` section defines the security boundary and hardware access rules for the application. Each argument configures the Flatpak bubblewrap container and `xdg-dbus-proxy`.
+
+```yaml
+finish-args:
+  # Display & Graphics
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --share=ipc
+  # Networking
+  - --share=network
+  # Audio
+  - --socket=pulseaudio
+  # D-Bus IPC
+  - --talk-name=org.freedesktop.secrets
+  - --system-talk-name=org.freedesktop.NetworkManager
+  - --own-name=org.example.App
+  # Filesystem
+  - --filesystem=xdg-download
+  - --filesystem=~/.cert/nm-openvpn:create
+  - --filesystem=/var/log/journal:ro
+```
+
+---
+
+### 3.1 Display & GUI Sockets
+
+GUI applications require display server sockets to communicate with Wayland compositors and X11 display servers.
+
+```
+                      +-----------------------------+
+                      | Application in Flatpak      |
+                      +-----------------------------+
+                                     |
+                    +----------------+----------------+
+                    |                                 |
+                    v                                 v
+          [--socket=wayland]               [--socket=fallback-x11]
+                    |                                 |
+           (Active Wayland Session)          (Active X11 Session)
+                    v                                 v
+         /run/user/$UID/wayland-0              /tmp/.X11-unix/X0
+          (Fully Isolated Surface)        (Legacy X11 Window System)
+```
+
+#### Display Socket Directives:
+
+| Argument | Description | Security Impact & Guidance |
+| :--- | :--- | :--- |
+| `--socket=wayland` | Grants access to the Wayland display socket (`/run/user/$UID/wayland-0`). | **Secure**. Wayland enforces client isolation, preventing screen scraping or keylogging between apps. |
+| `--socket=fallback-x11` | Grants access to X11 (`/tmp/.X11-unix/X0`) **only if** Wayland is not available. | **Recommended standard**. Enables Wayland on modern compositors while preserving backwards compatibility without granting unconditional X11 access. |
+| `--socket=x11` | Unconditionally opens the X11 display socket on both Wayland and X11 sessions. | **Discouraged on Flathub**. On Wayland, this forces Xwayland and allows the app to sniff keystrokes and windows of other Xwayland clients. |
+| `--share=ipc` | Shares the Inter-Process Communication (IPC) namespace with the host. | **Required for X11 MIT-SHM** shared memory extension to avoid GUI rendering performance degradation. |
+
+---
+
+### 3.2 Audio & Media Sockets
+
+| Argument | Target System | Description & Usage |
+| :--- | :--- | :--- |
+| `--socket=pulseaudio` | PulseAudio / PipeWire Pulse | Connects to `/run/user/$UID/pulse/native`. Enables audio playback and microphone capture. On modern systems, this communicates with PipeWire's PulseAudio emulation layer. |
+| `--socket=pipewire` | Native PipeWire (Direct) | Direct socket connection to PipeWire. Note: Most portal-aware applications should use the XDG Desktop Camera/ScreenCast portal rather than raw socket access. |
+
+---
+
+### 3.3 Peripheral & IPC Sockets
+
+| Argument | Socket Subsystem | Description & Usage Notes |
+| :--- | :--- | :--- |
+| `--socket=cups` | CUPS Printing Subsystem | Grants access to `/run/cups/cups.sock` for legacy direct print queue spooling. Modern apps should prefer the XDG Print Portal. |
+| `--socket=pcsc` | PC/SC Smart Card Subsystem | Grants access to `/run/pcscd/pcscd.comm` for hardware smart cards, PKCS#11 tokens, and cryptographic card readers. |
+| `--socket=ssh-auth` | SSH Agent Forwarding | Forwards `SSH_AUTH_SOCK` into the container for Git/SSH operations using host identities. |
+| `--socket=gpg-agent` | GnuPG Agent Socket | Forwards GPG keyring sockets for cryptographic signing and decryption. |
+
+---
+
+### 3.4 Filesystem Permissions & Modifiers
+
+Flatpak isolates the host filesystem. Applications always have exclusive read-write access to their private persistent sandbox directories:
+- `XDG_CONFIG_HOME` -> `~/.var/app/<app-id>/config/`
+- `XDG_DATA_HOME` -> `~/.var/app/<app-id>/data/`
+- `XDG_CACHE_HOME` -> `~/.var/app/<app-id>/cache/`
+
+Additional host filesystem access is explicitly granted using `--filesystem=...`.
+
+#### Permission Modifiers:
+- `:ro` -> **Read-Only**: The app can inspect files but cannot write, create, or delete.
+- `:rw` -> **Read-Write**: Default access mode if no modifier is specified.
+- `:create` -> **Create Directory**: Creates the directory on the host filesystem if it does not already exist before launching the sandbox.
+
+```yaml
+finish-args:
+  # Standard XDG well-known directories
+  - --filesystem=xdg-download
+  - --filesystem=xdg-pictures:ro
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-music:ro
+  - --filesystem=xdg-desktop
+
+  # Scoped host paths with creation modifier
+  - --filesystem=~/.cert/nm-openvpn/
+  - --filesystem=~/.cert:create
+  - --filesystem=~/.config/mpv:ro
+
+  # System paths
+  - --filesystem=/var/log/journal:ro
+  - --filesystem=/tmp
+```
+
+#### Filesystem Targets Reference Table:
+
+| Filesystem Target | Scope & Resolved Host Path | Appropriate Use Case |
+| :--- | :--- | :--- |
+| `xdg-download` | `~/Downloads` (`XDG_DOWNLOAD_DIR`) | Download managers, browsers, torrent clients. |
+| `xdg-pictures` | `~/Pictures` (`XDG_PICTURES_DIR`) | Photo editors, image viewers, graphic tools. |
+| `xdg-documents` | `~/Documents` (`XDG_DOCUMENTS_DIR`) | Document processors, PDF viewers, office suites. |
+| `xdg-music` | `~/Music` (`XDG_MUSIC_DIR`) | Music players, DAWs, taggers. |
+| `xdg-desktop` | `~/Desktop` (`XDG_DESKTOP_DIR`) | Desktop file utilities, icon managers. |
+| `xdg-run/<name>` | `/run/user/$UID/<name>` | Access to custom user-level daemon sockets. |
+| `~/<path>` | Scoped path relative to user `$HOME` | Preserving specific existing configuration/state dirs (e.g. `~/.cert/nm-openvpn`). |
+| `/var/log/journal:ro` | `/var/log/journal` (Systemd journal) | Diagnostic tools, VPN bug reporting, system logs. |
+| `home` | Entire user `$HOME` directory | **Strictly scrutinised on Flathub**. File managers, IDEs only. |
+| `host` | Entire host filesystem (`/`) | **Heavily restricted on Flathub**. Virtualization / system diagnostics only. |
+
+---
+
+### 3.5 D-Bus Mediation (Session & System Bus)
+
+Flatpak intercepts and filters all D-Bus traffic via `xdg-dbus-proxy`. Applications cannot communicate with D-Bus services unless explicitly permitted.
+
+```
++-------------------------------------------------------------+
+| Flatpak Application                                         |
++-------------------------------------------------------------+
+                              |
+                              v
+                +----------------------------+
+                |     xdg-dbus-proxy         |
+                |  (Security Policy Filter)  |
+                +----------------------------+
+                 /                          \
+                v                            v
+   [Session Bus: dbus-daemon]    [System Bus: dbus-daemon]
+   - org.freedesktop.secrets     - org.freedesktop.NetworkManager
+   - org.kde.StatusNotifier      - org.freedesktop.login1
+```
+
+#### D-Bus Directives:
+- `--talk-name=<bus-name>`: Allows sending calls and receiving replies from a specific service on the **Session Bus**.
+- `--own-name=<bus-name>`: Allows the application to register and own a service name on the **Session Bus**.
+- `--system-talk-name=<bus-name>`: Allows sending calls and receiving replies on the **System Bus**.
+- `--system-own-name=<bus-name>`: Allows owning a service name on the **System Bus** (rarely granted).
+
+#### Common Session Bus Services:
+
+| D-Bus Name | Service Purpose | Common Use Cases |
+| :--- | :--- | :--- |
+| `org.freedesktop.secrets` | Secret Service API (Keyrings) | Storing and retrieving encrypted credentials, API keys, tokens (GNOME Keyring, KeePassXC). |
+| `org.kde.StatusNotifierWatcher` | Tray Icon / AppIndicator API | Creating system tray icons and indicators across GNOME (via extension), KDE Plasma, and XFCE. |
+| `org.freedesktop.Notifications` | Desktop Notifications | Displaying notifications (used if XDG desktop notification portal is not utilized). |
+| `org.mpris.MediaPlayer2.*` | Media Player Remote Interfacing | Media playback controls for desktop shell / lock screen integration. |
+| `org.freedesktop.portal.*` | XDG Desktop Portals | Standard portal communication (enabled by default in runtime). |
+
+#### Common System Bus Services:
+
+| D-Bus Name | Service Purpose | Common Use Cases |
+| :--- | :--- | :--- |
+| `org.freedesktop.NetworkManager` | Host Network Management | Checking connection status, monitoring Wi-Fi/Ethernet links, managing VPN connections. |
+| `org.freedesktop.login1` | systemd-logind Management | Inhibiting sleep/suspend, monitoring system power/reboot states, reconnecting network daemons. |
+| `org.freedesktop.ModemManager1` | Cellular / Mobile Broadband | Controlling cellular modems, SMS, and mobile data connections. |
+| `org.freedesktop.UPower` | Power & Battery Management | Checking battery levels, power profiles, and charging status. |
+| `org.bluez` | Bluetooth Stack | Managing Bluetooth adapters, scanning, and pairing peripheral devices. |
+
+---
+
+### 3.6 Device & Subsystem Access
+
+| Argument | Subsystem / Device Node | Technical Scope & Security Implications |
+| :--- | :--- | :--- |
+| `--device=dri` | Direct Rendering Infrastructure (`/dev/dri/*`) | Enables hardware GPU acceleration for OpenGL, Vulkan, VA-API, and video decoding. **Standard for GUI apps**. |
+| `--device=kvm` | Kernel Virtual Machine (`/dev/kvm`) | Enables hardware virtualization acceleration. Required for QEMU, Android emulators, virtual machines. |
+| `--device=all` | All Devices (`/dev/*`, `/dev/bus/usb/*`, HID) | Raw device access. Required for USB security keys (FIDO2 / U2F), raw USB hardware, serial/CAN controllers. **Triggers Flathub review scrutiny**. |
+| `--device=shm` | Shared Memory (`/dev/shm`) | Grants access to host `/dev/shm` shared memory segment. |
+| `--share=network` | Network Namespace | Connects container to the host network stack. Enables TCP, UDP, DNS, and HTTP operations. |
+| `--share=ipc` | IPC Namespace | Shares SysV IPC and POSIX shared memory with the host. Required for high-performance X11 graphics rendering. |
+| `--unshare=network` | Network Isolation | Explicitly disables network access (default during build phase). |
+
+---
+
+## 4. Flathub Quality Standards & Least Privilege
+
+Flathub maintains strict review guidelines to protect end-user security and system integrity.
+
+### 4.1 The Principle of Least Privilege & XDG Portals
+
+Modern Flatpak applications should never request broad filesystem or device permissions when an **XDG Desktop Portal** (`org.freedesktop.portal.*`) can satisfy the requirement dynamically with user consent.
+
+```
++-------------------------------------------------------------------------------+
+|                      LEGACY PERMISSIONS VS MODERN PORTALS                     |
++-------------------------------------------------------------------------------+
+| Legacy (Discouraged)                     | Modern Portal (Recommended)        |
++------------------------------------------+------------------------------------+
+| --filesystem=home                        | org.freedesktop.portal.FileChooser |
+| --filesystem=/tmp                        | org.freedesktop.portal.OpenURI     |
+| --talk-name=org.freedesktop.secrets      | org.freedesktop.portal.Secret      |
+| --device=all (for webcams)               | org.freedesktop.portal.Camera      |
+| --talk-name=org.freedesktop.Notifications| org.freedesktop.portal.Notification|
++------------------------------------------+------------------------------------+
+```
+
+#### Why Portals Are Superior:
+1. **Dynamic User Consent**: When the user opens a file via `FileChooserPortal`, only the selected file is temporarily exposed to the container via FUSE document portal (`/run/user/$UID/doc/`).
+2. **Zero Ambient Authority**: The application cannot browse or exfiltrate private files in `$HOME`.
+3. **Desktop Native UX**: Dialogs render in the host theme and native environment.
+
+---
+
+### 4.2 Flathub Sensitive Permission Policy & Justifications
+
+During Flathub PR review, requests for broad permissions require explicit technical justification in the pull request description:
+
+| Sensitive Permission | Flathub Policy & Acceptable Justifications | Rejection Triggers |
+| :--- | :--- | :--- |
+| `--filesystem=host` / `--filesystem=host:ro` | **Strictly Restricted**. Only permitted for system administration tools, IDEs with terminal access, or container managers. | Requesting `host` for simple file browsing or media playing. |
+| `--filesystem=home` / `--filesystem=home:ro` | **Restricted**. Acceptable only for legacy software incapable of supporting the XDG FileChooser portal, or complex developer tools. | Requesting `home` when only `xdg-download` or `xdg-documents` is needed. |
+| `--device=all` | **Restricted**. Acceptable for hardware token authentication (FIDO2/Yubikey), flashing microcontrollers, or raw hardware debuggers. | Requesting `device=all` for webcams or audio input (use Portals/PulseAudio). |
+| `--socket=session-bus` / `--socket=system-bus` | **Strictly Forbidden**. Completely exposes the host D-Bus, bypassing all sandbox boundaries. | Automatically rejected by Flathub CI. Must use specific `--talk-name` / `--system-talk-name`. |
+| `--talk-name=org.freedesktop.Flatpak` | **Strictly Restricted**. Allows controlling Flatpak installations on the host. | Only allowed for Flatpak management GUI utilities. |
+
+---
+
+### 4.3 AppStream Metainfo Integration & Validation
+
+Every Flathub application must include a valid AppStream metainfo XML file located at `/app/share/metainfo/<app-id>.metainfo.xml` or `/app/share/appdata/<app-id>.appdata.xml`.
+
+#### Required AppStream Elements:
+- `<id>`: Must match the manifest `id` / `app-id` exactly.
+- `<metadata_license>`: Must be a permissive license (e.g. `FSFAP` or `CC0-1.0`).
+- `<project_license>`: SPDX license expression of the upstream application (e.g. `GPL-3.0-or-later`).
+- `<name>` & `<summary>`: Human-readable title and short single-sentence summary.
+- `<description>`: Formatted description paragraphs and bullet lists.
+- `<launchable type="desktop-id">`: References the desktop file (`<app-id>.desktop`).
+- `<screenshots>`: Publicly accessible screenshot URLs with aspect ratios.
+- `<releases>`: Release history with version tags, dates, and changelog descriptions.
+- `<content_rating type="oars-1.1" />`: OARS rating specification.
+
+#### Metainfo Validation Commands:
+```bash
+# Validate using appstream-util (checks syntax and Flathub constraints)
+appstream-util validate --nonet com.protonvpn.www.metainfo.xml
+
+# Validate using appstreamcli (checks specification compliance)
+appstreamcli validate --no-net com.protonvpn.www.metainfo.xml
+```
+
+---
+
+## 5. Real-World Manifest Blueprints & Auditing
+
+### 5.1 Blueprint 1: GNOME 50 / GTK4 / Libadwaita Desktop App
+
+A modern, portal-aware GTK4 desktop application written in Rust and compiled with Meson:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/flatpak/flatpak-builder/main/data/flatpak-manifest.schema.json
+
+id: org.gnome.ExampleApp
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: example-app
+
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-stable
+
+finish-args:
+  # Display & GPU
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+  # Networking
+  - --share=network
+  # Audio
+  - --socket=pulseaudio
+  # D-Bus Application Ownership
+  - --own-name=org.gnome.ExampleApp
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share/doc
+  - /share/man
+  - "*.la"
+  - "*.a"
+
+modules:
+  # C dependency built with Meson
+  - name: libexample-helper
+    buildsystem: meson
+    config-opts:
+      - -Dbuildtype=release
+      - -Dtests=false
+    sources:
+      - type: archive
+        url: https://github.com/example/libhelper/releases/download/v1.2.0/libhelper-1.2.0.tar.xz
+        sha256: 7f83b1657ff1...
+
+  # Main Application (Rust + Meson)
+  - name: example-app
+    buildsystem: meson
+    build-options:
+      append-path: /usr/lib/sdk/rust-stable/bin
+      env:
+        CARGO_HOME: /run/build/example-app/cargo-home
+    sources:
+      - type: git
+        url: https://gitlab.gnome.org/GNOME/example-app.git
+        tag: 1.0.0
+        commit: a1b2c3d4e5f6...
+      - cargo-sources.json
+```
+
+---
+
+### 5.2 Blueprint 2: System / Network Utility (Proton VPN Architecture)
+
+A hybrid Python/GTK system network utility requiring Secret Service integration, NetworkManager system bus communication, FIDO2 hardware security keys, and scoped filesystem access:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/flatpak/flatpak-builder/main/data/flatpak-manifest.schema.json
+
+id: com.protonvpn.www
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: protonvpn-app
+
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-stable
+
+finish-args:
+  # IPC and Host Network Stack
+  - --share=ipc
+  - --share=network
+
+  # GUI Wayland with X11 fallback
+  - --socket=wayland
+  - --socket=fallback-x11
+
+  # Secret Service API (Keyring credential storage)
+  - --talk-name=org.freedesktop.secrets
+
+  # System Bus: NetworkManager API for monitoring and VPN state
+  - --system-talk-name=org.freedesktop.NetworkManager
+
+  # System Bus: systemd-logind for sleep/wake hooks and DBus daemon reconnection
+  - --system-talk-name=org.freedesktop.login1
+
+  # Status Notifier tray icon integration
+  - --talk-name=org.kde.StatusNotifierWatcher
+
+  # D-Bus session name registration
+  - --own-name=proton.vpn.app.gtk
+
+  # Scoped Filesystem: OpenVPN configuration & certificate persistence
+  - --filesystem=~/.cert/nm-openvpn/
+  - --filesystem=~/.cert:create
+
+  # Scoped Filesystem: Read-only system journal access for diagnostics
+  - --filesystem=/var/log/journal:ro
+
+  # Hardware Devices: FIDO2 / U2F USB hardware security key authentication
+  - --device=all
+
+modules:
+  # Intltool translation utilities
+  - shared-modules/intltool/intltool-0.51.json
+
+  # Shared Python packaging tooling
+  - name: python3-packaging
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "packaging" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl
+        sha256: 29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484
+
+  # Native Rust-backed Python cryptography module using SDK extension
+  - name: python3-bcrypt
+    buildsystem: simple
+    build-options:
+      append-path: /usr/lib/sdk/rust-stable/bin
+      env:
+        CARGO_HOME: /run/build/python3-bcrypt/cargo-home
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "bcrypt" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/source/b/bcrypt/bcrypt-4.3.0.tar.gz
+        sha256: 4b29796e6a3ef73ef808b2dc1e16f316279f22c66860e6e76fc6d5b0373ab1b1
+      - bcrypt-cargo-sources.json
+
+  # Main Application Package
+  - name: proton-vpn-gtk-app
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} . --no-build-isolation
+      - install -Dm644 rpm/com.protonvpn.www.desktop /app/share/applications/com.protonvpn.www.desktop
+      - install -Dm644 rpm/com.protonvpn.www.metainfo.xml /app/share/metainfo/com.protonvpn.www.metainfo.xml
+      - install -Dm644 rpm/com.protonvpn.www.svg /app/share/icons/hicolor/scalable/apps/com.protonvpn.www.svg
+    sources:
+      - type: git
+        url: https://github.com/ProtonVPN/proton-vpn-gtk-app.git
+        tag: v4.12.0
+        commit: 81bca6a94fb21a37c35...
+```
+
+---
+
+### 5.3 Permission Auditing & Verification Tooling
+
+To ensure permissions adhere to the principle of least privilege and Flathub automated checks, use the following verification workflows:
+
+#### 1. Manifest Dependency and Permission Verification:
+```bash
+# Check dependencies and source modules declared in the manifest
+flatpak-builder --show-deps com.protonvpn.www.yml
+
+# Inspect configured sandbox permissions after building
+flatpak-builder --show-manifest com.protonvpn.www.yml
+```
+
+#### 2. Inspecting Installed Application Permissions:
+```bash
+# Display formatted permissions for an installed Flatpak
+flatpak info --show-permissions com.protonvpn.www
+
+# Output example:
+# [Context]
+# shared=ipc;network;
+# sockets=wayland;fallback-x11;
+# devices=all;
+# filesystems=/var/log/journal:ro;~/.cert:create;~/.cert/nm-openvpn;
+#
+# [Session Bus Policy]
+# org.freedesktop.secrets=talk
+# org.kde.StatusNotifierWatcher=talk
+# proton.vpn.app.gtk=own
+#
+# [System Bus Policy]
+# org.freedesktop.NetworkManager=talk
+# org.freedesktop.login1=talk
+```
+
+#### 3. Automated Linter Inspection (`flatpak-builder-lint`):
+```bash
+# Install and execute flatpak-builder-lint (Flathub CI standard tool)
+flatpak-builder-lint manifest com.protonvpn.www.yml
+flatpak-builder-lint appstream com.protonvpn.www.metainfo.xml
+flatpak-builder-lint repo build-dir/
+```
+
+#### 4. Permission Auditing Checklist:
+- [ ] **Wayland + X11**: `--socket=wayland` and `--socket=fallback-x11` used instead of unrestricted `--socket=x11`.
+- [ ] **IPC Sharing**: `--share=ipc` included for X11 rendering performance.
+- [ ] **Filesystem Scoping**: Avoided `--filesystem=home` or `--filesystem=host` unless strictly required.
+- [ ] **D-Bus Boundaries**: No wildcard `--socket=session-bus` or `--socket=system-bus`; all bus targets explicitly named.
+- [ ] **Device Access**: `--device=dri` for graphics; `--device=all` justified with hardware token (FIDO2) or peripheral usage.
+- [ ] **AppStream**: Metainfo XML validated cleanly with `appstream-util validate --nonet`.
+- [ ] **Language Server Schema**: Header `# yaml-language-server: $schema=...` present on line 1.

--- a/.agents/skills/creating-flatpaks/references/python-pip-offline.md
+++ b/.agents/skills/creating-flatpaks/references/python-pip-offline.md
@@ -1,0 +1,617 @@
+# Python / Pip Offline Dependency Management for Flatpak
+
+This reference guide provides a complete technical blueprint for packaging Python applications and Python libraries for Flatpak and Flathub. It explains the mechanics of Flatpak's offline build isolation, how to download and vendor Python dependencies ahead-of-time using `flatpak-pip-generator`, how to configure build backends and flags, and how to resolve complex native compilation and runtime dependency challenges.
+
+---
+
+## 1. Overview & Sandboxing Principles
+
+### Flatpak Build Isolation Model
+Flathub and `flatpak-builder` enforce a strict separation between source resolution and compilation:
+
+1. **Download Phase (Online)**: `flatpak-builder` parses the manifest and all included resource files, downloads every declared source archive, wheel, or git repository via the host network, and cryptographically verifies its `sha256` checksum.
+2. **Build Phase (Offline / Unshared Network)**: The build executes inside an isolated sandbox with the network namespace completely unshared (`--unshare=network`). Any attempt by `pip`, `setuptools`, `poetry`, or `cargo` to open a socket or query PyPI fails immediately with a network unreachable error.
+
+```
++-------------------------------------------------------------------------+
+| DOWNLOAD PHASE (Host Network Enabled)                                   |
+|   1. flatpak-builder reads com.example.App.yml and pip-resources.*.yaml |
+|   2. Downloads wheels (.whl) & source tarballs (.tar.gz) from PyPI      |
+|   3. Verifies SHA256 integrity against manifest declarations            |
++-------------------------------------------------------------------------+
+                                    |
+                                    v
++-------------------------------------------------------------------------+
+| BUILD PHASE (Network Namespace Unshared: NO NETWORK ACCESS)             |
+|   1. Downloaded archives unpacked into /run/build/<module-name>/        |
+|   2. pip3 install --no-index --find-links="file://${PWD}"               |
+|   3. pip3 searches only the local directory for matching packages       |
+|   4. Compiles C/Rust extensions & installs to /app (FLATPAK_DEST)       |
++-------------------------------------------------------------------------+
+```
+
+### The Offline Pip Paradigm
+Standard Python deployment workflows (`pip install <package>`) dynamically query the PyPI JSON/Simple API, download the latest matching wheel or source distribution, resolve transitive dependencies on the fly, and download build dependencies into temporary virtual environments.
+
+In Flatpak packaging:
+- **No Dynamic Index**: `pip` is invoked with `--no-index` to prevent querying remote package indexes.
+- **Local Link Directory**: `pip` is pointed to the build directory containing the downloaded artifacts using `--find-links="file://${PWD}"`.
+- **No Build Isolation**: `pip` is invoked with `--no-build-isolation` to prevent it from attempting to fetch PEP 517/518 build-time dependencies over the disabled network.
+- **Explicit Target Prefix**: Packages are installed into the Flatpak application tree via `--prefix=${FLATPAK_DEST}` (which expands to `/app`).
+
+---
+
+## 2. `flatpak-pip-generator` Tooling
+
+`flatpak-pip-generator` is the standard tool maintained within [flatpak-builder-tools](https://github.com/flatpak/flatpak-builder-tools) to automate the resolution, downloading, and YAML/JSON source block generation for Python dependencies.
+
+### 2.1 Installation & Setup
+
+You can obtain `flatpak-pip-generator` directly from the `flatpak-builder-tools` repository:
+
+```bash
+# Clone flatpak-builder-tools
+git clone https://github.com/flatpak/flatpak-builder-tools.git /tmp/flatpak-builder-tools
+
+# Add to PATH or invoke directly
+python3 /tmp/flatpak-builder-tools/pip/flatpak-pip-generator --help
+```
+
+### 2.2 CLI Invocations & Common Flags
+
+```bash
+# Generate YAML resources for a list of packages matching a specific runtime SDK
+flatpak-pip-generator \
+  --yaml \
+  --checker-data \
+  --runtime='org.gnome.Sdk//50' \
+  -o pip-resources.proton-vpn-cli \
+  click dbus-fast tabulate
+
+# Generate resources from a requirements.txt file
+flatpak-pip-generator \
+  --yaml \
+  --checker-data \
+  --runtime='org.gnome.Sdk//50' \
+  --requirements-file=requirements.txt \
+  -o pip-resources.my-app
+```
+
+#### Key Options Reference:
+- `--yaml`: Emits output in YAML format (the default is JSON).
+- `--checker-data`: Appends `x-checker-data` blocks to each package source entry, enabling automated update tracking with `flatpak-external-data-checker`.
+- `--runtime='<runtime-id>//<version>'`: Specifies the target Flatpak runtime (e.g. `org.gnome.Sdk//50` or `org.freedesktop.Sdk//24.08`). `flatpak-pip-generator` uses this to resolve matching Python version ABI tags (e.g. CPython 3.12).
+- `-o <filename>` / `--output <filename>`: Base output filename (writes `<filename>.yaml` or `<filename>.json`).
+- `-r <file>` / `--requirements-file <file>`: Reads package specifications from a standard `requirements.txt` file.
+
+### 2.3 Anatomy of Generated Source Blocks
+
+When `flatpak-pip-generator` runs, it queries PyPI for each package and its transitive dependency tree, resolves matching wheel or source distributions, and generates Flatpak module declarations:
+
+```yaml
+# Generated with flatpak-pip-generator --checker-data --yaml --runtime=org.gnome.Sdk//50 click dbus-fast tabulate -o pip-resources.proton-vpn-cli
+build-commands: []
+buildsystem: simple
+modules:
+- name: python3-click
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "click" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
+    sha256: 981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6
+    x-checker-data:
+      name: click
+      packagetype: bdist_wheel
+      type: pypi
+- name: python3-dbus-fast
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "dbus-fast" --no-build-isolation
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/4d/45/43e2826069e8ed2cb3a3b83da72d39a0fe52ece2eca3cac8ff5e070bbfa4/dbus_fast-2.45.1.tar.gz
+    sha256: 486195c42c5f8fac77e9c55b575e2c85636cff7db45ebc7a19f680b3b4084314
+    x-checker-data:
+      name: dbus-fast
+      packagetype: sdist
+      type: pypi
+name: pip-resources.proton-vpn-cli
+```
+
+### 2.4 YAML Anchors and Shared Dependencies
+When multiple modules share common dependencies (e.g. `pycairo` required by both `python3-pygobject` and `python3-pycairo`), `flatpak-pip-generator` uses standard YAML anchors (`&id001`) and references (`*id001`) to avoid duplicate downloads:
+
+```yaml
+modules:
+- name: python3-pygobject
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "pygobject" --no-build-isolation
+  sources:
+  - &id001
+    type: file
+    url: https://files.pythonhosted.org/packages/40/d9/412da520de9052b7e80bfc810ec10f5cb3dbfa4aa3e23c2820dc61cdb3d0/pycairo-1.28.0.tar.gz
+    sha256: 26ec5c6126781eb167089a123919f87baa2740da2cca9098be8b3a6b91cc5fbc
+  - type: file
+    url: https://files.pythonhosted.org/packages/a2/80/09247a2be28af2c2240132a0af6c1005a2b1d089242b13a2cd782d2de8d7/pygobject-3.56.2.tar.gz
+    sha256: b816098969544081de9eecedb94ad6ac59c77e4d571fe7051f18bebcec074313
+- name: python3-pycairo
+  buildsystem: simple
+  build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "pycairo" --no-build-isolation
+  sources:
+  - *id001
+```
+
+---
+
+## 3. Artifact Types & Resolution Strategy
+
+Selecting the right distribution format on PyPI is critical for reliable offline Flatpak compilation.
+
+### 3.1 Distribution Types
+
+| Artifact Type | Filename Pattern | Characteristics | Flatpak Suitability |
+|---|---|---|---|
+| **Pure Python Wheel** | `*-py3-none-any.whl` | Pre-built bytecode, no native C/Rust compilation needed. Zero build-backend overhead. | **Ideal**: Fastest to install, lowest build overhead. |
+| **Source Distribution (sdist)** | `*.tar.gz` / `*.zip` | Raw source tree. Built on-demand inside the Flatpak build container against runtime libraries. | **Required** for packages with C/C++/Rust extensions linking against SDK headers. |
+| **Pre-built Binary Wheel** | `*-cp312-cp312-manylinux_*.whl` | Pre-compiled binary against generic `manylinux` glibc standard. | **Use with caution**: May conflict with runtime system libraries or fail arch cross-compilation. |
+
+### 3.2 Why Source Distributions (sdist) are Favored for Native Extensions
+
+When a Python package contains native C/C++ extensions or Rust bindings (e.g. `pygobject`, `pycairo`, `bcrypt`, `cryptography`, `dbus-fast`, `psutil`):
+1. **ABI and Library Consistency**: Compiling from sdist ensures the extension links against the exact shared libraries (`glib2`, `cairo`, `gtk4`, `openssl`, `libsecret`) provided by the Flatpak runtime (e.g. `org.gnome.Platform//50`).
+2. **Multi-Architecture Support**: Flathub builds for multiple CPU architectures (`x86_64`, `aarch64`). An sdist is architecture-neutral in the manifest; `flatpak-builder` compiles it natively on each builder architecture.
+3. **Debugging and Symbol Stripping**: Source compilation respects Flatpak build options, producing valid `.debug` symbols for crash reporting and debugging extensions.
+
+### 3.3 Runtime SDK & Python Version Alignment
+
+Flatpak runtimes provide specific Python versions. Ensure your package resolutions and wheel compatibility tags match the target SDK:
+
+- **GNOME 50 / Freedesktop 24.08**: Python 3.12+ (CPython ABI: `cp312`)
+- **GNOME 49 / Freedesktop 23.08**: Python 3.11+ (CPython ABI: `cp311`)
+
+When running `flatpak-pip-generator`, always supply the exact target runtime (`--runtime='org.gnome.Sdk//50'`) so that it selects matching wheel ABI tags for packages where binary wheels are accepted.
+
+---
+
+## 4. Offline Installation Mechanics & Build Flags
+
+### 4.1 The Standard Build Command
+
+Every offline Python module in Flatpak uses the following standardized invocation:
+
+```bash
+pip3 install \
+  --verbose \
+  --exists-action=i \
+  --no-index \
+  --find-links="file://${PWD}" \
+  --prefix=${FLATPAK_DEST} \
+  --no-build-isolation \
+  "<package-name>"
+```
+
+For installing the application itself from the current source root:
+
+```bash
+pip3 install \
+  --verbose \
+  --exists-action=i \
+  --no-index \
+  --find-links="file://${PWD}" \
+  --prefix=${FLATPAK_DEST} \
+  --no-build-isolation \
+  "."
+```
+
+#### Detailed Flag Breakdown:
+- `--verbose`: Prints detailed wheel building and installation logs, which are essential for debugging CI build failures on Flathub.
+- `--exists-action=i`: Ignore existing installed packages if encountered.
+- `--no-index`: Completely ignores PyPI and all package indexes.
+- `--find-links="file://${PWD}"`: Tells pip to search for `.whl` and `.tar.gz` files in the current build directory where Flatpak placed the downloaded `sources`.
+- `--prefix=${FLATPAK_DEST}`: Directs installation into `/app` (`/app/lib/python3.12/site-packages` and `/app/bin`).
+- `--no-build-isolation`: **Critical flag**. Disables PEP 517/518 isolated build environments.
+
+### 4.2 Why `--no-build-isolation` is Essential
+
+Under PEP 517 and PEP 518, `pip` defaults to build isolation:
+1. When building a package with a `pyproject.toml`, pip creates a temporary virtualenv in `/tmp`.
+2. Pip reads `[build-system] requires = [...]` (e.g. `["setuptools>=61.0", "wheel", "flit_core>=3.2"]`).
+3. Pip attempts to connect to PyPI to install those build tools into the temporary virtualenv.
+4. In Flatpak's unshared network sandbox, this network request **fails instantly**.
+
+By passing `--no-build-isolation`, you force pip to use the build backends already installed in the Flatpak build environment (`/usr` from the SDK, or `/app` from preceding manifest modules).
+
+### 4.3 Pre-Installing Build Backends & Build-Time Tools
+
+Because build isolation is disabled, all build backends specified in `build-system.requires` must be present before the module is built.
+
+Common build backends and build tools include:
+- `setuptools` & `wheel` (Standard setuptools builds)
+- `flit_core` (Lightweight pure Python packages, e.g. `typing_extensions`, `tomli`)
+- `poetry-core` (Poetry-based packages)
+- `hatchling` (Hatch-based packages)
+- `setuptools_scm` (Version extraction from SCM/git tags)
+- `maturin` / `setuptools-rust` (Rust-backed Python extensions)
+- `scikit-build` / `ninja` (CMake-backed C/C++ extensions)
+- `cython` (C-extension transpiler)
+- `editables`, `pathspec`, `calver`, `pluggy`, `packaging`
+
+### 4.4 The Build Backend Module Pattern (`cleanup: ['*']`)
+
+When build tools are only needed during compilation and should not bloat the final Flatpak runtime image, declare them as nested submodules with `cleanup: ['*']`:
+
+```yaml
+  - name: python3-my-package
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "my-package" --no-build-isolation
+    modules:
+      # Build dependency required only during build
+      - name: python3-flit_core
+        buildsystem: simple
+        cleanup: ['*']
+        build-commands:
+          - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+            --prefix=${FLATPAK_DEST} "flit_core" --no-build-isolation
+        sources:
+          - type: file
+            url: https://files.pythonhosted.org/packages/69/59/b6fc2188dfc7ea4f936cd12b49d707f66a1cb7a1d2c16172963534db741b/flit_core-3.12.0.tar.gz
+            sha256: 18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2
+            x-checker-data:
+              name: flit_core
+              type: pypi
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/ab/cd/.../my_package-1.0.0.tar.gz
+        sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+```
+
+`cleanup: ['*']` ensures that all files installed by `python3-flit_core` into `${FLATPAK_DEST}` are purged before the final Flatpak runtime bundle is created, leaving only the compiled target package.
+
+---
+
+## 5. Modularization Patterns & Manifest Integration
+
+In complex applications (such as Proton VPN), having dozens of Python dependencies directly in the main manifest file (`com.example.App.yml`) makes maintenance unmanageable. Splitting dependencies into modular resource files is the recommended Flathub pattern.
+
+### 5.1 Modular File Organization
+
+A clean repository structure separates concerns by component:
+
+```
+com.protonvpn.www/
+├── com.protonvpn.www.yml                  # Main application manifest
+├── pip-resources.python-skbuild.yaml       # Build tools (scikit-build, ninja)
+├── pip-resources.python-proton-core.yaml   # Core networking dependencies
+├── pip-resources.python-proton-keyring-linux.yaml # Secret service / keyring deps
+├── pip-resources.python-proton-vpn-api-core.yaml  # API / FIDO2 / Crypto deps
+├── pip-resources.proton-vpn-cli.yaml       # CLI specific dependencies
+├── pip-resources.proton-vpn-gtk-app.yaml   # GTK UI specific dependencies (PyGObject, PyCairo)
+└── bcrypt-cargo-sources.json               # Cargo vendored sources for Rust extensions
+```
+
+### 5.2 Manifest Integration Patterns
+
+#### Pattern A: Including as Submodule in `modules:`
+This pattern is ideal when a group of dependencies belongs to a specific sub-component of your build:
+
+```yaml
+  - name: proton-vpn-cli
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "." --no-build-isolation
+    modules:
+      - pip-resources.proton-vpn-cli.yaml
+    sources:
+      - type: git
+        url: https://github.com/ProtonVPN/proton-vpn-cli.git
+        tag: v1.0.3
+        commit: a7c7abc8d3777f33b8d4c82279bd621258bd810d
+```
+
+#### Pattern B: Top-Level Module Inclusions
+Modular files can also be referenced directly in the root `modules` list of the manifest:
+
+```yaml
+modules:
+  - pip-resources.python-proton-core.yaml
+  - pip-resources.python-proton-keyring-linux.yaml
+  - pip-resources.python-proton-vpn-api-core.yaml
+  - name: my-main-application
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "." --no-build-isolation
+```
+
+---
+
+## 6. Handling Native Extensions (Rust, CMake, CFFI, GObject)
+
+### 6.1 PyO3 / `setuptools-rust` Extensions (e.g. `bcrypt`, `cryptography`)
+
+Packages combining Python with Rust native code require both the Python build backend (`setuptools-rust`, `semantic_version`, `flit_core`) and the Rust toolchain with offline Cargo sources:
+
+```yaml
+  # Python bcrypt library with native Rust extension
+  - name: python3-bcrypt
+    build-options:
+      append-path: /usr/lib/sdk/rust-stable/bin
+      env:
+        CARGO_HOME: /run/build/python3-bcrypt/cargo
+        CARGO_NET_OFFLINE: 'true'
+        RUST_BACKTRACE: '1'
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "bcrypt" --no-build-isolation
+    modules:
+      # Build dependencies required by setuptools-rust
+      - name: python3-flit_core
+        buildsystem: simple
+        cleanup: ['*']
+        build-commands:
+          - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+            --prefix=${FLATPAK_DEST} "flit_core" --no-build-isolation
+        sources:
+          - type: file
+            url: https://files.pythonhosted.org/packages/69/59/b6fc2188dfc7ea4f936cd12b49d707f66a1cb7a1d2c16172963534db741b/flit_core-3.12.0.tar.gz
+            sha256: 18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2
+
+      - name: python3-setuptools_rust
+        buildsystem: simple
+        cleanup: ['*']
+        build-commands:
+          - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+            --prefix=${FLATPAK_DEST} "setuptools_rust" --no-build-isolation
+        sources:
+          - type: file
+            url: https://files.pythonhosted.org/packages/7d/31/f2289ce78b9b473d582568c234e104d2a342fd658cc288a7553d83bb8595/semantic_version-2.10.0.tar.gz
+            sha256: bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c
+          - type: file
+            url: https://files.pythonhosted.org/packages/68/ba/b31781d61bf9ee3c232a1d1160db11c11cdeae1d44e06c90723b25a8279f/setuptools_rust-1.13.0.tar.gz
+            sha256: f2afcf4baeee689910ce49cfa8aad4e08cce72f417449bcc32891b8664fdc726
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/bb/5d/6d7433e0f3cd46ce0b43cd65e1db465ea024dbb8216fb2404e919c2ad77b/bcrypt-4.3.0.tar.gz
+        sha256: 3a3fd2204178b6d2adcf09cb4f6426ffef54762577a7c9b54c159008cb288c18
+      # Cargo sources generated via flatpak-cargo-generator.py
+      - bcrypt-cargo-sources.json
+```
+
+### 6.2 CMake / `scikit-build` Extensions
+
+For packages using `scikit-build` to drive CMake compilation (e.g. `ninja`, C++ wrappers):
+1. Install `ninja` and `scikit-build` in a prior module or nested module.
+2. Ensure CMake finds host compilers and libraries in `${FLATPAK_DEST}` and `/usr`.
+
+```yaml
+  - name: python-skbuild
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" .
+    cleanup: ['*']
+    sources:
+      - type: archive
+        url: https://files.pythonhosted.org/packages/9e/e2/2e440c30e93fc5b505ee56169a4396b05e797a1daadb721aba429adbfd51/scikit-build-0.15.0.tar.gz
+        sha256: e723cd0f3489a042370b9ea988bbb9cfd7725e8b25b20ca1c7981821fcf65fb9
+```
+
+### 6.3 PyGObject & PyCairo Extensions
+
+Packages interacting with GTK4 / Libadwaita require `pygobject` and `pycairo`. These compile against C headers (`gobject-introspection-1.0`, `cairo`, `gtk4`) provided by `org.gnome.Sdk`.
+
+```yaml
+  - name: proton-vpn-gtk-app
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "." --no-build-isolation
+    modules:
+      - pip-resources.proton-vpn-gtk-app.yaml
+```
+
+---
+
+## 7. Automated Upstream Updating
+
+### 7.1 Flatpak External Data Checker (`x-checker-data`)
+
+Flathub's automated bot (`flatpak-external-data-checker`) scans manifest source entries for `x-checker-data` annotations and automatically opens PRs when newer versions are released.
+
+#### PyPI Checker Schema:
+```yaml
+sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
+    sha256: 981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6
+    x-checker-data:
+      type: pypi
+      name: click
+      packagetype: bdist_wheel # or sdist
+```
+
+- `type: pypi`: Directs the checker to query `https://pypi.org/pypi/<name>/json`.
+- `name`: PyPI package name.
+- `packagetype`: `bdist_wheel` (for wheels) or `sdist` (for source tarballs).
+
+### 7.2 Custom Downstream Automation (`fedora_flatpak_updater`)
+
+Repositories maintaining complex packages (like `com.protonvpn.www`) often use custom automated updater tools (e.g. `scripts/fedora_flatpak_updater`) to synchronize dependencies with downstream Linux distributions (Fedora stable) and PyPI:
+
+```bash
+# Check and preview dependency updates against Fedora / PyPI
+uv run --project scripts/fedora_flatpak_updater python -m fedora_flatpak_updater.cli --dry-run
+
+# Regenerate pip resource manifests when dependencies change
+flatpak-pip-generator --checker-data --yaml --runtime='org.gnome.Sdk//50' \
+  click dbus-fast tabulate -o pip-resources.proton-vpn-cli
+```
+
+---
+
+## 8. Real-World End-to-End Manifest Examples
+
+### Example 1: Standalone Pure Python CLI Application
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/flatpak/flatpak-builder/main/data/flatpak-manifest.schema.json
+id: org.example.PythonCli
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+command: example-cli
+
+finish-args:
+  - --share=network
+  - --filesystem=home
+
+modules:
+  - name: python3-dependencies
+    buildsystem: simple
+    build-commands: []
+    modules:
+      - pip-resources.example-cli.yaml
+
+  - name: example-cli
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "." --no-build-isolation
+    sources:
+      - type: git
+        url: https://github.com/example/example-cli.git
+        tag: v1.0.0
+        commit: 1234567890abcdef1234567890abcdef12345678
+```
+
+---
+
+### Example 2: Desktop GTK4 / Libadwaita Python Application with Assets
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/flatpak/flatpak-builder/main/data/flatpak-manifest.schema.json
+id: com.example.GtkApp
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: example-gtk-app
+
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --talk-name=org.freedesktop.secrets
+
+modules:
+  # Included modular Python dependencies
+  - pip-resources.example-app.yaml
+
+  - name: example-gtk-app
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "." --no-build-isolation
+
+      # Install Desktop file and icon metadata
+      - install -Dm644 data/com.example.GtkApp.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
+      - install -Dm644 data/icons/com.example.GtkApp.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
+      - install -Dm644 data/com.example.GtkApp.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
+
+    sources:
+      - type: git
+        url: https://github.com/example/example-gtk-app.git
+        tag: v2.0.0
+        commit: abcdef0123456789abcdef0123456789abcdef01
+```
+
+---
+
+## 9. Troubleshooting & Common Pitfalls
+
+### 9.1 Error: Network Connection Attempt During Build
+```
+pip._vendor.urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPSConnection object>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution
+```
+**Cause**: Missing `--no-build-isolation` or missing `--no-index`. Pip attempted to query PyPI to create an isolated build environment or fetch a missing dependency.
+**Solution**:
+1. Verify that `--no-build-isolation` and `--no-index --find-links="file://${PWD}"` are present in `build-commands`.
+2. Ensure every transitive dependency is declared in `sources` or included `pip-resources.*.yaml`.
+
+---
+
+### 9.2 Error: Missing Build Backend (`ModuleNotFoundError: No module named 'flit_core'`)
+```
+ModuleNotFoundError: No module named 'flit_core'
+error: subprocess-exited-with-error
+```
+**Cause**: The package uses `flit_core` (or `setuptools_scm`, `poetry-core`, `hatchling`) as its build backend in `pyproject.toml`, but it is not installed in the SDK or earlier manifest modules.
+**Solution**:
+Add a preceding module or nested submodule with `cleanup: ['*']` that installs `flit_core` before building the target package.
+
+---
+
+### 9.3 Error: Wheel ABI / Architecture Incompatibility
+```
+ERROR: package-1.0.0-cp311-cp311-manylinux_2_17_x86_64.whl is not a supported wheel on this platform.
+```
+**Cause**:
+1. The wheel was compiled for Python 3.11 (`cp311`), but the Flatpak runtime provides Python 3.12 (`cp312`).
+2. Or a wheel built for `x86_64` was attempted on an `aarch64` builder.
+**Solution**:
+- Regenerate dependencies using `flatpak-pip-generator --runtime='org.gnome.Sdk//50'` to fetch Python 3.12 compatible wheels.
+- For packages with native code, switch to source distributions (`sdist`, `.tar.gz`) instead of platform-specific binary wheels.
+
+---
+
+### 9.4 Executable Entry Point Shebang & `$PATH` Issues
+```
+bash: /app/bin/my-tool: /usr/bin/python3: bad interpreter: No such file or directory
+```
+**Cause**: Pip installed an entry point script with a shebang pointing to `/usr/bin/python3`, but runtime packages reside in `/app`.
+**Solution**:
+In the Flatpak environment, `/usr/bin/python3` is provided by the runtime. If the script cannot find `/app/lib/python3.12/site-packages`, ensure `PYTHONPATH` or environment setup includes `/app`:
+
+```yaml
+build-options:
+  env:
+    PYTHONPATH: /app/lib/python3.12/site-packages
+```
+
+Alternatively, fix shebangs in post-install commands:
+```yaml
+build-commands:
+  - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "." --no-build-isolation
+  - sed -i '1s|.*|#!/usr/bin/env python3|' ${FLATPAK_DEST}/bin/my-tool
+```
+
+---
+
+### 9.5 Python `site-packages` Directory Path Discrepancies (`lib` vs `lib64`)
+On 64-bit Linux distributions, some distutils/setuptools configurations may place packages into `/app/lib64/python3.12/site-packages` instead of `/app/lib/python3.12/site-packages`.
+
+**Solution**:
+Create a symbolic link if necessary in post-install or module build commands:
+```yaml
+build-commands:
+  - |
+    if [ -d "${FLATPAK_DEST}/lib64" ] && [ ! -e "${FLATPAK_DEST}/lib" ]; then
+      ln -s lib64 "${FLATPAK_DEST}/lib"
+    fi
+```
+
+---
+
+### 9.6 Dependency Version Pin Conflicts Across Modular Sub-Manifests
+When multiple `pip-resources.*.yaml` sub-manifests require different versions of a shared transitive dependency (e.g. `requests==2.31.0` vs `requests==2.32.3`):
+1. The latter module will overwrite the former in `/app/lib/python3.12/site-packages`.
+2. If versions are incompatible, runtime breakage can occur.
+
+**Solution**:
+- Align shared dependency versions across all `pip-resources.*.yaml` files.
+- Run `flatpak-pip-generator` with all packages in a single invocation when possible, or synchronize versions across modular files using an automated updater tool like `fedora_flatpak_updater`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,9 +36,28 @@ flatpak-builder --download-only build-dir com.protonvpn.www.yml
 flatpak run com.protonvpn.www protonvpn --help
 flatpak run com.protonvpn.www
 
-# Run updater test suite
-scripts/fedora_flatpak_updater/.venv/bin/pytest tests/fedora_flatpak_updater -v
+# Regenerate proton-vpn-platform-cargo-sources.json after python-proton-vpn-api-core bump
+scripts/generate_proton_platform_sources.py
+
+# Run test suite
+scripts/fedora_flatpak_updater/.venv/bin/pytest tests/ -v
 ```
+
+---
+
+## Automated Bot PR Triage (`flatpak-external-data-checker`)
+
+When Flathub's automated checker creates a PR bumping `python-proton-vpn-api-core`, follow this checklist to bring CI to green:
+
+1. **Synchronize `dependencies/protun`**:
+   - Check the `protun` version pinned in `Cargo.lock` (reported by `scripts/generate_proton_platform_sources.py`).
+   - Update `tag` and `commit` for `dependencies/protun` in [`com.protonvpn.www.yml`](com.protonvpn.www.yml) to match.
+2. **Regenerate Cargo Sources**:
+   - Run `scripts/generate_proton_platform_sources.py` to regenerate [`proton-vpn-platform-cargo-sources.json`](proton-vpn-platform-cargo-sources.json).
+3. **Re-anchor Patches**:
+   - Verify that [`patches/python-proton-vpn-api-core/remove-local-agent-dep.patch`](patches/python-proton-vpn-api-core/remove-local-agent-dep.patch) applies cleanly against upstream `setup.py`.
+4. **Preserve Dependency Build Order**:
+   - If upstream added new requirements to `setup.py` (e.g. `dbus-fast`), ensure they are declared in [`pip-resources.python-proton-vpn-api-core.yaml`](pip-resources.python-proton-vpn-api-core.yaml) so they are installed before `python-proton-vpn-api-core` compiles.
 
 ---
 
@@ -50,14 +69,15 @@ scripts/fedora_flatpak_updater/.venv/bin/pytest tests/fedora_flatpak_updater -v
 
 2. **Rust & Sparse Registry Vendoring (`proton-vpn-platform`)**:
    - `python-proton-vpn-api-core` relies on Proton's sparse registry (`sparse+https://rust-registry.proton.me/index/`).
-   - Standard `flatpak-cargo-generator.py` points non-git crates to `static.crates.io`. Proton crates must explicitly use `https://rust-registry.proton.me/downloads/{crate}@{version}.crate` in [`proton-vpn-platform-cargo-sources.json`](file:///home/slash/Development/com.protonvpn.www/proton-vpn-platform-cargo-sources.json).
+   - Standard `flatpak-cargo-generator.py` points non-git crates to `static.crates.io`. Proton crates must explicitly use `https://rust-registry.proton.me/downloads/{crate}@{version}.crate` in [`proton-vpn-platform-cargo-sources.json`](proton-vpn-platform-cargo-sources.json).
    - The embedded `cargo/config.toml` must replace `sparse+https://rust-registry.proton.me/index/` with `vendored-sources` and define both `[registries.proton]` and `[registries.proton_public]`.
-   - If upstream tagged releases contain stale internal lockfiles, maintain [`patches/python-proton-vpn-api-core/update-cargo-lock.patch`](file:///home/slash/Development/com.protonvpn.www/patches/python-proton-vpn-api-core/update-cargo-lock.patch) to satisfy `cargo build --locked`.
+   - Use [`scripts/generate_proton_platform_sources.py`](scripts/generate_proton_platform_sources.py) to automatically regenerate [`proton-vpn-platform-cargo-sources.json`](proton-vpn-platform-cargo-sources.json) whenever `python-proton-vpn-api-core` is bumped.
+   - Upstream releases starting at `v5.6.10+` natively point to `rust-registry.proton.me`, making `update-cargo-lock.patch` obsolete.
 
 3. **Python Pip Offline Builds**:
    - Always pass `--no-build-isolation` to `pip3 install` to prevent pip from querying PyPI for build environments.
    - Build-time dependencies (`setuptools_rust`, `flit_core`, `skbuild`, `meson`) must be installed as preceding or nested modules.
-   - Strip removed/redundant requirements (e.g. `proton-vpn-local-agent`) via patches in [`patches/`](file:///home/slash/Development/com.protonvpn.www/patches/).
+   - Strip removed/redundant requirements (e.g. `proton-vpn-local-agent`) via patches in [`patches/`](patches/).
 
 4. **Security & System Permissions**:
    - Manifest `finish-args` must remain minimal and compliant with Flathub standards.

--- a/scripts/generate_proton_platform_sources.py
+++ b/scripts/generate_proton_platform_sources.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Generate proton-vpn-platform-cargo-sources.json for Flatpak offline vendoring.
+
+This script parses Cargo.lock from python-proton-vpn-api-core, runs flatpak-cargo-generator.py,
+rewrites Proton-hosted sparse registry crate URLs to https://rust-registry.proton.me/downloads/,
+and injects the offline sparse registry cargo configuration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = REPO_ROOT / "com.protonvpn.www.yml"
+DEFAULT_OUTPUT = REPO_ROOT / "proton-vpn-platform-cargo-sources.json"
+GENERATOR_URL = "https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/cargo/flatpak-cargo-generator.py"
+PROTON_SPARSE_REGISTRY = "sparse+https://rust-registry.proton.me/index/"
+PROTON_DOWNLOAD_BASE = "https://rust-registry.proton.me/downloads"
+
+OFFLINE_CARGO_CONFIG = """[source.vendored-sources]
+directory = "cargo/vendor"
+
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source."sparse+https://rust-registry.proton.me/index/"]
+registry = "sparse+https://rust-registry.proton.me/index/"
+replace-with = "vendored-sources"
+
+[registries.proton]
+index = "sparse+https://rust-registry.proton.me/index/"
+
+[registries.proton_public]
+index = "sparse+https://rust-registry.proton.me/index/"
+"""
+
+
+def parse_proton_crates(cargo_lock_text: str) -> set[tuple[str, str]]:
+    """Extract (crate_name, version) pairs originating from Proton's sparse registry."""
+    pattern = (
+        r'\[\[package\]\]\n'
+        r'name\s*=\s*"([^"]+)"\n'
+        r'version\s*=\s*"([^"]+)"\n'
+        r'source\s*=\s*"sparse\+https://rust-registry\.proton\.me/index/"'
+    )
+    return set(re.findall(pattern, cargo_lock_text))
+
+
+def get_protun_version(cargo_lock_text: str) -> str | None:
+    """Extract the required version of protun from Cargo.lock."""
+    match = re.search(
+        r'\[\[package\]\]\nname\s*=\s*"protun"\nversion\s*=\s*"([^"]+)"',
+        cargo_lock_text,
+    )
+    return match.group(1) if match else None
+
+
+def get_manifest_tag(manifest_path: Path) -> str:
+    """Read the current tag for python-proton-vpn-api-core from the Flatpak manifest."""
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"Manifest not found: {manifest_path}")
+
+    content = manifest_path.read_text(encoding="utf-8")
+    # Locate module: python-proton-vpn-api-core and extract tag
+    match = re.search(
+        r'name:\s*python-proton-vpn-api-core.*?'
+        r'url:\s*https://github\.com/ProtonVPN/python-proton-vpn-api-core.*?'
+        r'tag:\s*([^\s\n]+)',
+        content,
+        re.DOTALL,
+    )
+    if not match:
+        raise ValueError(
+            f"Could not locate python-proton-vpn-api-core tag in {manifest_path}"
+        )
+    return match.group(1)
+
+
+def fetch_cargo_lock_from_tag(tag: str) -> str:
+    """Fetch Cargo.lock from ProtonVPN/python-proton-vpn-api-core GitHub repository."""
+    url = f"https://raw.githubusercontent.com/ProtonVPN/python-proton-vpn-api-core/{tag}/Cargo.lock"
+    req = urllib.request.Request(url, headers={"User-Agent": "ProtonVPN-Flatpak-Updater/1.0"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return resp.read().decode("utf-8")
+
+
+def rewrite_cargo_sources(
+    raw_sources: list[dict],
+    proton_crates: set[tuple[str, str]],
+) -> list[dict]:
+    """Rewrite crates.io URLs to Proton registry URLs and inject offline cargo config."""
+    updated_sources = []
+
+    for item in raw_sources:
+        if item.get("type") == "archive":
+            url = item.get("url", "")
+            for name, ver in proton_crates:
+                crates_io_url = f"https://static.crates.io/crates/{name}/{name}-{ver}.crate"
+                if url == crates_io_url:
+                    item = dict(item)
+                    item["url"] = f"{PROTON_DOWNLOAD_BASE}/{name}@{ver}.crate"
+                    break
+        updated_sources.append(item)
+
+    # Ensure trailing inline config sets up sparse registry vendoring
+    if updated_sources and updated_sources[-1].get("dest") == "cargo":
+        updated_sources[-1] = {
+            "type": "inline",
+            "contents": OFFLINE_CARGO_CONFIG,
+            "dest": "cargo",
+            "dest-filename": "config.toml",
+        }
+    else:
+        updated_sources.append(
+            {
+                "type": "inline",
+                "contents": OFFLINE_CARGO_CONFIG,
+                "dest": "cargo",
+                "dest-filename": "config.toml",
+            }
+        )
+
+    return updated_sources
+
+
+def find_python_with_aiohttp() -> str:
+    """Find a Python interpreter that has aiohttp installed for flatpak-cargo-generator."""
+    try:
+        subprocess.run(
+            [sys.executable, "-c", "import aiohttp"],
+            check=True,
+            capture_output=True,
+        )
+        return sys.executable
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
+    venv_python = REPO_ROOT / "scripts" / "fedora_flatpak_updater" / ".venv" / "bin" / "python"
+    if venv_python.is_file() and os.access(venv_python, os.X_OK):
+        return str(venv_python)
+
+    return sys.executable
+
+
+def generate_sources(
+    cargo_lock_text: str,
+    output_path: Path,
+) -> None:
+    """Run flatpak-cargo-generator on cargo_lock_text and write adjusted sources to output_path."""
+    proton_crates = parse_proton_crates(cargo_lock_text)
+    print(f"Found {len(proton_crates)} Proton registry crates in Cargo.lock.")
+
+    protun_version = get_protun_version(cargo_lock_text)
+    if protun_version:
+        print(f"Proton protun requirement: v{protun_version}")
+
+    python_bin = find_python_with_aiohttp()
+
+    # Download flatpak-cargo-generator.py
+    req = urllib.request.Request(GENERATOR_URL, headers={"User-Agent": "ProtonVPN-Flatpak-Updater/1.0"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        generator_code = resp.read()
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        temp_dir_path = Path(tempdir)
+        script_file = temp_dir_path / "flatpak-cargo-generator.py"
+        script_file.write_bytes(generator_code)
+
+        lock_file = temp_dir_path / "Cargo.lock"
+        lock_file.write_text(cargo_lock_text, encoding="utf-8")
+
+        temp_sources = temp_dir_path / "sources.json"
+
+        cmd = [python_bin, str(script_file), str(lock_file), "-o", str(temp_sources)]
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"flatpak-cargo-generator.py failed with code {proc.returncode}:\n"
+                f"stdout: {proc.stdout}\n"
+                f"stderr: {proc.stderr}"
+            )
+
+        with open(temp_sources, encoding="utf-8") as f:
+            raw_sources = json.load(f)
+
+        final_sources = rewrite_cargo_sources(raw_sources, proton_crates)
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        temp_output = output_path.parent / f".tmp_{output_path.name}"
+        with open(temp_output, "w", encoding="utf-8") as f:
+            json.dump(final_sources, f, indent=4)
+            f.write("\n")
+
+        shutil.move(temp_output, output_path)
+        print(f"Successfully wrote {len(final_sources)} sources to {output_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate proton-vpn-platform-cargo-sources.json from Cargo.lock"
+    )
+    parser.add_argument(
+        "--cargo-lock",
+        "-l",
+        type=Path,
+        help="Path to local Cargo.lock file (if omitted, fetched from git tag)",
+    )
+    parser.add_argument(
+        "--tag",
+        "-t",
+        help="Git tag for python-proton-vpn-api-core (e.g. v5.6.10, defaults to tag in manifest)",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Path to output cargo-sources.json file (default: proton-vpn-platform-cargo-sources.json)",
+    )
+    parser.add_argument(
+        "--manifest",
+        "-m",
+        type=Path,
+        default=DEFAULT_MANIFEST,
+        help="Path to com.protonvpn.www.yml manifest",
+    )
+    args = parser.parse_args()
+
+    if args.cargo_lock:
+        print(f"Reading Cargo.lock from {args.cargo_lock}...")
+        cargo_lock_text = args.cargo_lock.read_text(encoding="utf-8")
+    else:
+        tag = args.tag or get_manifest_tag(args.manifest)
+        print(f"Fetching Cargo.lock for tag '{tag}'...")
+        cargo_lock_text = fetch_cargo_lock_from_tag(tag)
+
+    generate_sources(cargo_lock_text, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_generate_proton_platform_sources.py
+++ b/tests/test_generate_proton_platform_sources.py
@@ -1,0 +1,105 @@
+import tempfile
+from pathlib import Path
+
+from scripts.generate_proton_platform_sources import (
+    get_manifest_tag,
+    get_protun_version,
+    parse_proton_crates,
+    rewrite_cargo_sources,
+)
+
+SAMPLE_CARGO_LOCK = """
+version = 3
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deadbeef"
+
+[[package]]
+name = "proton-boringtun"
+version = "3.0.0"
+source = "sparse+https://rust-registry.proton.me/index/"
+checksum = "d6cbef9a3ddc5f97501607f1a689c459a1894069745b4cede7c519b71bb64434"
+
+[[package]]
+name = "protun"
+version = "2.2.1"
+dependencies = [
+ "derive_more",
+]
+
+[[package]]
+name = "pvpnclient"
+version = "3.0.3"
+source = "sparse+https://rust-registry.proton.me/index/"
+checksum = "3c14ef052727e0204ec5e80cf8df50786db38a83b6a6557a188b78a4c264f380"
+"""
+
+SAMPLE_MANIFEST = """
+modules:
+  - name: python-proton-vpn-api-core
+    sources:
+      - type: git
+        url: https://github.com/ProtonVPN/python-proton-vpn-api-core
+        tag: v5.6.10
+        commit: f1d13b71c506bbd5f47351a9e4392572e21d0169
+"""
+
+
+def test_parse_proton_crates() -> None:
+    crates = parse_proton_crates(SAMPLE_CARGO_LOCK)
+    assert crates == {("proton-boringtun", "3.0.0"), ("pvpnclient", "3.0.3")}
+
+
+def test_get_protun_version() -> None:
+    version = get_protun_version(SAMPLE_CARGO_LOCK)
+    assert version == "2.2.1"
+
+
+def test_get_manifest_tag() -> None:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+        f.write(SAMPLE_MANIFEST)
+        temp_path = Path(f.name)
+
+    try:
+        tag = get_manifest_tag(temp_path)
+        assert tag == "v5.6.10"
+    finally:
+        temp_path.unlink()
+
+
+def test_rewrite_cargo_sources() -> None:
+    raw_sources = [
+        {
+            "type": "archive",
+            "url": "https://static.crates.io/crates/serde/serde-1.0.228.crate",
+            "sha256": "deadbeef",
+            "dest": "cargo/vendor/serde-1.0.228",
+        },
+        {
+            "type": "archive",
+            "url": "https://static.crates.io/crates/proton-boringtun/proton-boringtun-3.0.0.crate",
+            "sha256": "d6cbef9a3ddc5f97501607f1a689c459a1894069745b4cede7c519b71bb64434",
+            "dest": "cargo/vendor/proton-boringtun-3.0.0",
+        },
+        {
+            "type": "inline",
+            "contents": "[source.crates-io]\nreplace-with = 'vendored-sources'",
+            "dest": "cargo",
+            "dest-filename": "config",
+        },
+    ]
+
+    proton_crates = {("proton-boringtun", "3.0.0")}
+    rewritten = rewrite_cargo_sources(raw_sources, proton_crates)
+
+    assert len(rewritten) == 3
+    # Standard crate is untouched
+    assert rewritten[0]["url"] == "https://static.crates.io/crates/serde/serde-1.0.228.crate"
+    # Proton crate URL is rewritten
+    assert rewritten[1]["url"] == "https://rust-registry.proton.me/downloads/proton-boringtun@3.0.0.crate"
+    # Config entry uses config.toml and contains sparse registry setup
+    assert rewritten[2]["dest-filename"] == "config.toml"
+    assert "https://rust-registry.proton.me/index/" in rewritten[2]["contents"]


### PR DESCRIPTION
## Summary

1. **Automation Script**:
   - Adds `scripts/generate_proton_platform_sources.py` to automate regenerating `proton-vpn-platform-cargo-sources.json` from upstream tags or local `Cargo.lock` files.
   - Maps Proton sparse registry crates (`sparse+https://rust-registry.proton.me/index/`) directly to `https://rust-registry.proton.me/downloads/{name}@{version}.crate`.
   - Injects the offline sparse registry configuration into `cargo/config.toml`.
   - Adds comprehensive unit tests in `tests/test_generate_proton_platform_sources.py` (all 71 tests passing).

2. **Agent Skills & Reference Guides**:
   - Commits the missing skill files under `.agents/skills/creating-flatpaks/`:
     - `SKILL.md`: End-to-end packaging and maintenance runbook.
     - `references/manifest-structure-and-permissions.md`: Permissions, finish-args, D-Bus filtering, and portal guides.
     - `references/python-pip-offline.md`: Offline Python/pip dependency management reference.

3. **Documentation & Operational Runbook**:
   - Updates `AGENTS.md` with quick-reference commands, automated bot PR triage workflow, and notes deprecating `update-cargo-lock.patch` for `v5.6.10+`.